### PR TITLE
PopulationProcessor update

### DIFF
--- a/Pulsar4X/Pulsar4X.ECSLib/DataBlobs/ColonyLifeSupportDB.cs
+++ b/Pulsar4X/Pulsar4X.ECSLib/DataBlobs/ColonyLifeSupportDB.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Pulsar4X.ECSLib
+{
+    public class ColonyLifeSupportDB : BaseDataBlob
+    {
+        public long MaxPopulation { get; set; }
+
+        public ColonyLifeSupportDB()
+        {
+            MaxPopulation = new long();
+        }
+
+        public ColonyLifeSupportDB(ColonyLifeSupportDB db)
+        {
+            MaxPopulation = db.MaxPopulation;
+        }
+
+        public override object Clone()
+        {
+            return new ColonyLifeSupportDB(this);
+        }
+    }
+}

--- a/Pulsar4X/Pulsar4X.ECSLib/Processors/Econ Subprocessors/PopulationProcessor.cs
+++ b/Pulsar4X/Pulsar4X.ECSLib/Processors/Econ Subprocessors/PopulationProcessor.cs
@@ -90,5 +90,25 @@ namespace Pulsar4X.ECSLib
                 }
             }
         }
+
+        public static void ReCalcMaxPopulation(Entity colonyEntity)
+        {
+
+            var infrastructure = new List<Entity>();
+
+            List<KeyValuePair<Entity, List<ComponentInstance>>> infrastructureEntities = colonyEntity.GetDataBlob<ComponentInstancesDB>().SpecificInstances.Where(item => item.Key.HasDataBlob<PopulationSupportAbilityDB>()).ToList();
+            long totalMaxPop = 0;
+
+            foreach (var infrastructureDesignList in infrastructureEntities)
+            {
+                foreach (var infrastructureInstance in infrastructureDesignList.Value)
+                {
+                    totalMaxPop += infrastructureDesignList.Key.GetDataBlob<PopulationSupportAbilityDB>().PopulationCapacity;
+                }
+            }
+
+            colonyEntity.GetDataBlob<ColonyLifeSupportDB>().MaxPopulation = totalMaxPop;
+
+        }
     }
 }

--- a/Pulsar4X/Pulsar4X.ECSLib/Processors/Econ Subprocessors/PopulationProcessor.cs
+++ b/Pulsar4X/Pulsar4X.ECSLib/Processors/Econ Subprocessors/PopulationProcessor.cs
@@ -14,7 +14,6 @@ namespace Pulsar4X.ECSLib
             List<KeyValuePair<Entity, List<ComponentInstance>>> infrastructure = colony.GetDataBlob<ComponentInstancesDB>().SpecificInstances.Where(item => item.Key.HasDataBlob<PopulationSupportAbilityDB>()).ToList();
             long popSupportValue;
 
-            // @todo: Get colony cost and infrastructure, figure out population cap
             //  Pop Cap = Total Population Support Value / Colony Cost
             // Get total popSupport
             popSupportValue = 0;
@@ -30,18 +29,14 @@ namespace Pulsar4X.ECSLib
             foreach (KeyValuePair<Entity, long> kvp in currentPopulation)
             {
                 // count the number of different population groups that need infrastructure support
-                if (SpeciesProcessor.ColonyCost(colony, kvp.Key.GetDataBlob<SpeciesDB>()) > 1.0)
+                if (SpeciesProcessor.ColonyCost(colony.GetDataBlob<ColonyInfoDB>().PlanetEntity, kvp.Key.GetDataBlob<SpeciesDB>()) > 1.0)
                     needsSupport++;
             }
 
             // find colony cost, divide the population support value by it
-            // @todo: Get colony cost, or do I need to calculate it?
-
-
-
             foreach (KeyValuePair<Entity, long> kvp in currentPopulation.ToArray())
             {
-                double colonyCost = SpeciesProcessor.ColonyCost(colony, kvp.Key.GetDataBlob<SpeciesDB>());
+                double colonyCost = SpeciesProcessor.ColonyCost(colony.GetDataBlob<ColonyInfoDB>().PlanetEntity, kvp.Key.GetDataBlob<SpeciesDB>());
                 long maxPopulation;
                 double growthRate;
                 long newPop;

--- a/Pulsar4X/Pulsar4X.ECSLib/Processors/ReCalcProcessor.cs
+++ b/Pulsar4X/Pulsar4X.ECSLib/Processors/ReCalcProcessor.cs
@@ -14,6 +14,7 @@ namespace Pulsar4X.ECSLib
                 { typeof(PropulsionDB), new Action<PropulsionDB>(processor => { ShipMovementProcessor.CalcMaxSpeed(CurrentEntity); }) },
                 { typeof(ColonyRefiningDB), new Action<ColonyRefiningDB>(processor => { RefiningProcessor.ReCalcRefiningRate(CurrentEntity); }) },
                 { typeof(ColonyConstructionDB), new Action<ColonyConstructionDB>(processor => { ConstructionProcessor.ReCalcConstructionRate(CurrentEntity); }) },
+                { typeof(ColonyLifeSupportDB), new Action<ColonyLifeSupportDB>(processor => {PopulationProcessor.ReCalcMaxPopulation(CurrentEntity); }) },
                 { typeof(ShipInfoDB), new Action<ShipInfoDB>(processor => {ShipAndColonyInfoProcessor.ReCalculateShipTonnaageAndHTK(CurrentEntity); }) },
             };
 
@@ -29,7 +30,6 @@ namespace Pulsar4X.ECSLib
                         TypeProcessorMap[t].DynamicInvoke(datablob); // invoke appropriate delegate  
                 }                
             }
-
         }
     }
 }

--- a/Pulsar4X/Pulsar4X.ECSLib/Processors/SpeciesProcessor.cs
+++ b/Pulsar4X/Pulsar4X.ECSLib/Processors/SpeciesProcessor.cs
@@ -79,6 +79,13 @@ namespace Pulsar4X.ECSLib
             float totalPressure = 0.0f;
             AtmosphereDB atmosphere = planet.GetDataBlob<AtmosphereDB>();
 
+            if(atmosphere == null)
+            {
+                // No atmosphere on the planet, return 1.0?
+                // @todo - some other rule for no atmosphere planets?
+                return 1.0;
+            }
+
             Dictionary<AtmosphericGasSD, float> atmosphereComp = atmosphere.Composition;
 
             foreach (KeyValuePair<AtmosphericGasSD, float> kvp in atmosphereComp)
@@ -120,6 +127,13 @@ namespace Pulsar4X.ECSLib
             float O2Pressure = 0.0f;
             float totalPressure = 0.0f;
             AtmosphereDB atmosphere = planet.GetDataBlob<AtmosphereDB>();
+
+            if (atmosphere == null)
+            {
+                // No atmosphere on the planet, return 2.0?
+                // @todo - some other rule for no atmosphere planets?
+                return 2.0;
+            }
 
             Dictionary<AtmosphericGasSD, float> atmosphereComp = atmosphere.Composition;
 

--- a/Pulsar4X/Pulsar4X.ECSLib/Pulsar4X.ECSLib.csproj
+++ b/Pulsar4X/Pulsar4X.ECSLib/Pulsar4X.ECSLib.csproj
@@ -164,6 +164,7 @@
     <Compile Include="DataBlobs\AbilityDBs\PowerGeneratorAbilityDB.cs" />
     <Compile Include="DataBlobs\AbilityDBs\StandardShieldAbilityDB.cs" />
     <Compile Include="DataBlobs\ColonyConstructionDB.cs" />
+    <Compile Include="DataBlobs\ColonyLifeSupportDB.cs" />
     <Compile Include="Factories\ShipComponents\ComponentDesign.cs" />
     <Compile Include="DataBlobs\AbilityDBs\ConstructionAbilityDB.cs" />
     <Compile Include="DataBlobs\AbilityDBs\EnginePowerDB.cs" />

--- a/Pulsar4X/Pulsar4X.Tests/PopulationProcessorTest.cs
+++ b/Pulsar4X/Pulsar4X.Tests/PopulationProcessorTest.cs
@@ -103,31 +103,35 @@ namespace Pulsar4X.Tests
 
             int i, j, k;
 
-            // Create a new colony with this planet and species, add infrastructure item to it
-            _colonyEntity = ColonyFactory.CreateColony(_faction, species, planet);
-
             Guid infGUID = new Guid("08b3e64c-912a-4cd0-90b0-6d0f1014e9bb");
             ComponentTemplateSD infrastructureSD = _game.StaticData.Components[infGUID];
             ComponentDesign infrastructureDesign = GenericComponentFactory.StaticToDesign(infrastructureSD, _faction.GetDataBlob<FactionTechDB>(), _game.StaticData);
             Entity infrastructureEntity = GenericComponentFactory.DesignToEntity(_game, _faction, infrastructureDesign);
 
-            ShipAndColonyInfoProcessor.AddComponentDesignToEntity(infrastructureEntity, _colonyEntity);
-            ReCalcProcessor.ReCalcAbilities(_colonyEntity);
-
             Dictionary<Entity, long> pop = _colonyEntity.GetDataBlob<ColonyInfoDB>().Population;
 
 
             // Single iteration growth test
-            for (i = 0; i < basePop.Length; i++)
+            for (i = 0; i < infrastructureAmounts.Length; i++)
             {
-                for (j = 0; j < infrastructureAmounts.Length; j++)
+                // Create a new colony with this planet and species, add infrastructure item to it
+                _colonyEntity = ColonyFactory.CreateColony(_faction, species, planet);
+
+                // Add the correct number of infrastructure to the colony
+                for (k = 0; k < infrastructureAmounts[i]; k++)
+                    ShipAndColonyInfoProcessor.AddComponentDesignToEntity(infrastructureEntity, _colonyEntity);
+                ReCalcProcessor.ReCalcAbilities(_colonyEntity);
+
+
+                for (j = 0; j < basePop.Length; j++)
                 {
+
                     // set up population and infrastructure for each test
                     newPop = _colonyEntity.GetDataBlob<ColonyInfoDB>().Population;
 
                     foreach (KeyValuePair<Entity, long> kvp in newPop.ToArray())
                     {
-                        newPop[kvp.Key] = basePop[i];
+                        newPop[kvp.Key] = basePop[j];
                     }
 
                     //var infrastuctures = _colonyEntity.GetDataBlob<ComponentInstancesDB>().SpecificInstances[infrastructureEntity].Where(inf => inf.DesignEntity.HasDataBlob<LifeSupportAbilityDB>());
@@ -145,16 +149,24 @@ namespace Pulsar4X.Tests
 
 
             // Multiple iteration growth test
-            for (i = 0; i < basePop.Length; i++)
+            for (i = 0; i < infrastructureAmounts.Length; i++)
             {
-                for (j = 0; j < infrastructureAmounts.Length; j++)
+                // Create a new colony with this planet and species, add infrastructure item to it
+                _colonyEntity = ColonyFactory.CreateColony(_faction, species, planet);
+
+                // Add the correct number of infrastructure to the colony
+                for (k = 0; k < infrastructureAmounts[i]; k++)
+                    ShipAndColonyInfoProcessor.AddComponentDesignToEntity(infrastructureEntity, _colonyEntity);
+                ReCalcProcessor.ReCalcAbilities(_colonyEntity);
+
+                for (j = 0; j < basePop.Length; j++)
                 {
                     // set up population and infrastructure for each test
                     newPop = _colonyEntity.GetDataBlob<ColonyInfoDB>().Population;
 
                     foreach (KeyValuePair<Entity, long> kvp in newPop.ToArray())
                     {
-                        newPop[kvp.Key] = basePop[i];
+                        newPop[kvp.Key] = basePop[j];
                     }
 
                     _colonyEntity.GetDataBlob<InstallationsDB>().Installations[infGUID] = infrastructureAmounts[j];

--- a/Pulsar4X/Pulsar4X.Tests/PopulationProcessorTest.cs
+++ b/Pulsar4X/Pulsar4X.Tests/PopulationProcessorTest.cs
@@ -76,7 +76,21 @@ namespace Pulsar4X.Tests
             _entityManager = null;
             _faction = null;
             _colonyEntity = null;
-        }
+
+
+            _earthPlanet = null;
+            _marsPlanet = null;
+            _lunaPlanet = null; ;
+            _galaxyFactory = null;
+            _starSystemFactory = null;
+            _starSystem = null; 
+            _gasDictionary.Clear();
+            _gasDictionary = null;
+            _planetsList.Clear();
+            _planetsList = null;
+            _speciesList.Clear();
+            _speciesList = null;
+    }
 
         [Test]
         public void testPopulationGrowth()
@@ -169,8 +183,6 @@ namespace Pulsar4X.Tests
                         newPop[kvp.Key] = basePop[j];
                     }
 
-                    _colonyEntity.GetDataBlob<InstallationsDB>().Installations[infGUID] = infrastructureAmounts[j];
-
                     for(k = 0; k < 10; k++)
                     {
                         newPop = calcGrowthIteration(_colonyEntity, newPop);
@@ -216,11 +228,11 @@ namespace Pulsar4X.Tests
         {
             // Get current population
             Dictionary<Entity, long> returnPop = new Dictionary<Entity, long>();
-            
+            Entity colonyPlanet = colony.GetDataBlob<ColonyInfoDB>().PlanetEntity;
+
             List<KeyValuePair<Entity, List<ComponentInstance>>> infrastructure = colony.GetDataBlob<ComponentInstancesDB>().SpecificInstances.Where(item => item.Key.HasDataBlob<PopulationSupportAbilityDB>()).ToList();
             long popSupportValue;
 
-            // @todo: Get colony cost and infrastructure, figure out population cap
             //  Pop Cap = Total Population Support Value / Colony Cost
             // Get total popSupport
             popSupportValue = 0;
@@ -229,7 +241,6 @@ namespace Pulsar4X.Tests
 
             foreach (var installation in infrastructure)
             {
-                //if(installations[kvp.Key]
                 popSupportValue += installation.Key.GetDataBlob<PopulationSupportAbilityDB>().PopulationCapacity;
             }
 
@@ -238,18 +249,13 @@ namespace Pulsar4X.Tests
             foreach (KeyValuePair<Entity, long> kvp in lastPop)
             {
                 // count the number of different population groups that need infrastructure support
-                if (SpeciesProcessor.ColonyCost(colony, kvp.Key.GetDataBlob<SpeciesDB>()) > 1.0)
+                if (SpeciesProcessor.ColonyCost(colonyPlanet, kvp.Key.GetDataBlob<SpeciesDB>()) > 1.0)
                     needsSupport++;
             }
 
-            // find colony cost, divide the population support value by it
-            // @todo: Get colony cost, or do I need to calculate it?
-
-
-
             foreach (KeyValuePair<Entity, long> kvp in lastPop.ToArray())
             {
-                double colonyCost = SpeciesProcessor.ColonyCost(colony, kvp.Key.GetDataBlob<SpeciesDB>());
+                double colonyCost = SpeciesProcessor.ColonyCost(colonyPlanet, kvp.Key.GetDataBlob<SpeciesDB>());
                 long maxPopulation;
                 long newPop;
 
@@ -273,12 +279,14 @@ namespace Pulsar4X.Tests
         private Entity setEarthPlanet()
         {
             Entity resultPlanet;
+
             Dictionary<AtmosphericGasSD, float> atmoGasses = new Dictionary<AtmosphericGasSD, float>();
 
             atmoGasses.Add(_gasDictionary["N"], 0.79f);
             atmoGasses.Add(_gasDictionary["O"], 0.20f);
             atmoGasses.Add(_gasDictionary["Ar"], 0.01f);
             AtmosphereDB atmosphereDB = new AtmosphereDB(1f, true, 71, 1f, 1f, 0.3f, 57.2f, atmoGasses);
+
             resultPlanet = setAtmosphere(atmosphereDB);
 
             resultPlanet.GetDataBlob<SystemBodyDB>().BaseTemperature = 14.0f;

--- a/Pulsar4X/Pulsar4X.Tests/PopulationProcessorTest.cs
+++ b/Pulsar4X/Pulsar4X.Tests/PopulationProcessorTest.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using Pulsar4X.ECSLib;
-using System.Diagnostics;
 
 namespace Pulsar4X.Tests
 {
@@ -42,20 +41,31 @@ namespace Pulsar4X.Tests
             // Set up planets
             // @todo: add more planets
             _earthPlanet = setEarthPlanet();
-            
 
+            _planetsList = new List<Entity>();
+            _planetsList.Add(_earthPlanet);
 
 
             // Set up species
             // @todo: add more species
             Entity species = SpeciesFactory.CreateSpeciesHuman(_faction, _entityManager);
 
+            _speciesList = new List<Entity>();
+            _speciesList.Add(species);
+
 
             // Set up colonies
             // @todo: add more colonies, especially ones with multiple species in one colony
             _colonyEntity = ColonyFactory.CreateColony(_faction, species, _earthPlanet);
-            
-            _colonyEntity.GetDataBlob<ComponentInstancesDB>().SpecificInstances.Add()
+
+            ComponentTemplateSD infrastructureSD = _game.StaticData.Components[new Guid("08b3e64c-912a-4cd0-90b0-6d0f1014e9bb")];
+            ComponentDesign infrastructureDesign = GenericComponentFactory.StaticToDesign(infrastructureSD, _faction.GetDataBlob<FactionTechDB>(), _game.StaticData);
+            Entity infrastructureEntity = GenericComponentFactory.DesignToEntity(_game, _faction, infrastructureDesign);
+
+            ShipAndColonyInfoProcessor.AddComponentDesignToEntity(infrastructureEntity, _colonyEntity);
+
+            ReCalcProcessor.ReCalcAbilities(_colonyEntity);
+
         }
 
         [TearDown]
@@ -71,32 +81,57 @@ namespace Pulsar4X.Tests
         [Test]
         public void testPopulationGrowth()
         {
-            // Assumption - the population of any planet will not reach the maximum size of a long variable type, therefore
-            // I am not testing that edge case
+            // Set the colony population to five million to start
 
-            /*
-            // @todo: fix
-            Dictionary<Entity, long> returnedPop;
+            foreach (var planet in _planetsList)
+            {
+                foreach (var species in _speciesList)
+                {
+                    // set up population and infrastructure for each test
+                    testPlanetAndSpecies(planet, species);
+                }
 
+            }
 
+        }
+
+        private void testPlanetAndSpecies(Entity planet, Entity species)
+        {
             long[] basePop = new long[] { 0, 5, 10, 100, 999, 1000, 10000, 100000, 10000000 };
             long[] infrastructureAmounts = new long[] { 0, 1, 5, 100 };
-            Dictionary<Entity, long> newPop;
+            Dictionary<Entity, long> newPop, returnedPop;
 
-            // Set the colony population to five million to start
+            int i, j, k;
+
+            // Create a new colony with this planet and species, add infrastructure item to it
+            _colonyEntity = ColonyFactory.CreateColony(_faction, species, planet);
+
+            Guid infGUID = new Guid("08b3e64c-912a-4cd0-90b0-6d0f1014e9bb");
+            ComponentTemplateSD infrastructureSD = _game.StaticData.Components[infGUID];
+            ComponentDesign infrastructureDesign = GenericComponentFactory.StaticToDesign(infrastructureSD, _faction.GetDataBlob<FactionTechDB>(), _game.StaticData);
+            Entity infrastructureEntity = GenericComponentFactory.DesignToEntity(_game, _faction, infrastructureDesign);
+
+            ShipAndColonyInfoProcessor.AddComponentDesignToEntity(infrastructureEntity, _colonyEntity);
+            ReCalcProcessor.ReCalcAbilities(_colonyEntity);
+
             Dictionary<Entity, long> pop = _colonyEntity.GetDataBlob<ColonyInfoDB>().Population;
 
+
             // Single iteration growth test
-            int i, j;
-
-
-
             for (i = 0; i < basePop.Length; i++)
             {
                 for (j = 0; j < infrastructureAmounts.Length; j++)
                 {
                     // set up population and infrastructure for each test
                     newPop = _colonyEntity.GetDataBlob<ColonyInfoDB>().Population;
+
+                    foreach (KeyValuePair<Entity, long> kvp in newPop.ToArray())
+                    {
+                        newPop[kvp.Key] = basePop[i];
+                    }
+
+                    //var infrastuctures = _colonyEntity.GetDataBlob<ComponentInstancesDB>().SpecificInstances[infrastructureEntity].Where(inf => inf.DesignEntity.HasDataBlob<LifeSupportAbilityDB>());
+
                     returnedPop = calcGrowthIteration(_colonyEntity, newPop);
                     PopulationProcessor.GrowPopulation(_colonyEntity);
 
@@ -108,134 +143,34 @@ namespace Pulsar4X.Tests
 
             }
 
-            newPop = _colonyEntity.GetDataBlob<ColonyInfoDB>().Population;
-            returnedPop = calcGrowthIteration(_colonyEntity, newPop);
-            PopulationProcessor.GrowPopulation(_colonyEntity);
-
 
             // Multiple iteration growth test
-            for (int j = 1; j < 10; j++)
-            {
-
-                for (i = 0; i < basePop.Length; i++)
-                {
-                    foreach (KeyValuePair<Entity, long> kvp in pop.ToArray())
-                    {
-                        if (pop.ContainsKey(kvp.Key))
-                        {
-                            pop[kvp.Key] = basePop[i];
-                        }
-                        newPop = basePop[i];
-
-                        for (int k = 0; k < j; k++)
-                        {
-                            newPop = calcGrowthIteration(newPop);
-                            PopulationProcessor.GrowPopulation(_colonyEntity);
-                        }
-
-                        Assert.AreEqual(returnedPop[kvp.Key], pop[kvp.Key]);
-                    }
-                }
-            }*/
-
-        }
-
-        private void testPlanetAndSpecies(Entity planet, Entity species)
-        {
-            long[] basePop = new long[] { 0, 5, 10, 100, 999, 1000, 10000, 100000, 10000000 };
-            long[] infrastructureAmounts = new long[] { 0, 1, 5, 100 };
-            Dictionary<Entity, long> newPop, returnedPop;
-
-            Entity testColony;
-
-            long maxPop, lastPop;
-
-            // Set the colony population to five million to start
-            Dictionary<Entity, long> pop = _colonyEntity.GetDataBlob<ColonyInfoDB>().Population;
-
-            // Single iteration growth test
-            int i, j;
-
-            // Create a new colony with this planet and species
-            testColony = ColonyFactory.CreateColony(_faction, species, planet);
-
-            // Create an infrastructure item
-            List<KeyValuePair<Entity, List<ComponentInstance>>> infrastructure = testColony.GetDataBlob<ComponentInstancesDB>().SpecificInstances.Where(item => item.Key.HasDataBlob<PopulationSupportAbilityDB>()).ToList();
-
-            if (infrastructure.LongCount() == 0) // Empty
-            {
-                // Add infrastructure to the list of installations
-                //Entity infraItem = new Entity(;
-
-                //ComponentInfoDB infra = ;
-                //infra.
-
-                //testColony.GetDataBlob<ComponentInstancesDB>().SpecificInstances
-            }
-
             for (i = 0; i < basePop.Length; i++)
             {
                 for (j = 0; j < infrastructureAmounts.Length; j++)
                 {
-                    int supportValue = 0;
-
                     // set up population and infrastructure for each test
-                    newPop = testColony.GetDataBlob<ColonyInfoDB>().Population;
+                    newPop = _colonyEntity.GetDataBlob<ColonyInfoDB>().Population;
+
                     foreach (KeyValuePair<Entity, long> kvp in newPop.ToArray())
                     {
                         newPop[kvp.Key] = basePop[i];
                     }
 
-                    for(int k = 0; k < infrastructureAmounts[j]; k++)
+                    _colonyEntity.GetDataBlob<InstallationsDB>().Installations[infGUID] = infrastructureAmounts[j];
+
+                    for(k = 0; k < 10; k++)
                     {
-
-
-                        foreach (var installation in infrastructure)
-                        {
-                            supportValue += installation.Key.GetDataBlob<LifeSupportAbilityDB>().LifeSupportCapacity;
-                        }
-                        
+                        newPop = calcGrowthIteration(_colonyEntity, newPop);
+                        PopulationProcessor.GrowPopulation(_colonyEntity);
                     }
-
-                        returnedPop = calcGrowthIteration(_colonyEntity, newPop);
-                    PopulationProcessor.GrowPopulation(_colonyEntity);
 
                     foreach (KeyValuePair<Entity, long> kvp in pop.ToArray())
                     {
-                        Assert.AreEqual(returnedPop[kvp.Key], pop[kvp.Key]);
+                        Assert.AreEqual(newPop[kvp.Key], pop[kvp.Key]);
                     }
                 }
 
-            }
-
-            newPop = _colonyEntity.GetDataBlob<ColonyInfoDB>().Population;
-            returnedPop = calcGrowthIteration(_colonyEntity, newPop);
-            PopulationProcessor.GrowPopulation(_colonyEntity);
-
-
-            // Multiple iteration growth test
-            for (j = 1; j < 10; j++)
-            {
-
-                for (i = 0; i < basePop.Length; i++)
-                {
-                    foreach (KeyValuePair<Entity, long> kvp in pop.ToArray())
-                    {
-                        if (pop.ContainsKey(kvp.Key))
-                        {
-                            pop[kvp.Key] = basePop[i];
-                        }
-                        newPop[kvp.Key] = basePop[i];
-
-                        for (int k = 0; k < j; k++)
-                        {
-                            newPop = calcGrowthIteration(testColony, newPop);
-                            PopulationProcessor.GrowPopulation(testColony);
-                        }
-
-                        Assert.AreEqual(returnedPop[kvp.Key], pop[kvp.Key]);
-                    }
-                }
             }
         }
 
@@ -353,58 +288,7 @@ namespace Pulsar4X.Tests
             return resultPlanet;
         }
 
-        private void AddComponentDesignToEntity(ComponentInstance specificInstance, Entity parentEntity)
-        {
-            if (parentEntity.HasDataBlob<ComponentInstancesDB>())
-            {
-                ComponentInstancesDB componentInstance = parentEntity.GetDataBlob<ComponentInstancesDB>();
 
-                if (!componentInstance.SpecificInstances.ContainsKey(specificInstance.DesignEntity)) //if the entity doesnt already have this component design listed, 
-                    componentInstance.SpecificInstances.Add(specificInstance.DesignEntity, new List<ComponentInstance>()); //add the design ID to the dictionary with a new empty list
-                componentInstance.SpecificInstances[specificInstance.DesignEntity].Add(specificInstance); //add the specificInstance
-                ReCalcProcessor.ReCalcAbilities(parentEntity);
-            }
-            else throw new Exception("parentEntiy does not contain a ComponentInstanceDB");
-        }
-
-        public static ComponentTemplateSD InfrastructureInstallation()
-        {
-            ComponentTemplateSD component = new ComponentTemplateSD();
-            component.Name = "Infrastructure";
-            component.Description = "Component and buildings needed to keep colonists alive on hostile worlds";
-            component.ID = new Guid("08b3e64c-912a-4cd0-90b0-6d0f1014e9bb");
-
-            component.SizeFormula = "1";
-
-            component.HTKFormula = "[Size]";
-
-            component.CrewReqFormula = "0";
-
-            component.ResearchCostFormula = "0";
-
-            component.BuildPointCostFormula = "[Size]";
-
-            component.MineralCostFormula = new Dictionary<Guid, string> {{new Guid("2dfc78ea-f8a4-4257-bc04-47279bf104ef"), "10"}};
-
-            component.CreditCostFormula = "0";
-
-            component.MountType = ComponentMountType.PlanetInstallation | ComponentMountType.ShipCargo;
-
-            component.ComponentAbilitySDs = new List<ComponentTemplateAbilitySD>();
-
-
-            ComponentTemplateAbilitySD infrastructureAbility = new ComponentTemplateAbilitySD();
-            infrastructureAbility.Name = "Support Colonists";
-            infrastructureAbility.Description = "Keeps colonists alive on hostile worlds";
-            infrastructureAbility.GuiHint = GuiHint.None;
-            infrastructureAbility.GuidDictionary = new Dictionary<object, string>
-            {
-            };
-            infrastructureAbility.AbilityDataBlobType = typeof(LifeSupportAbilityDB).ToString();
-            component.ComponentAbilitySDs.Add(infrastructureAbility);
-
-            return component;
-        }
     }
 
 

--- a/Pulsar4X/Pulsar4X.sln
+++ b/Pulsar4X/Pulsar4X.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pulsar4X.Tests", "Pulsar4X.Tests\Pulsar4X.Tests.csproj", "{DBB8EAB5-4DBD-B54F-94C3-3B2EEA3C8B4E}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -21,9 +21,6 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pulsar4X.CrossPlatformUI.Mac", "Pulsar4X.CrossPlatformUI.Mac\Pulsar4X.CrossPlatformUI.Mac.csproj", "{D6CC2C60-BDF3-4379-A4C7-40AD6170A504}"
 EndProject
 Global
-	GlobalSection(Performance) = preSolution
-		HasPerformanceSessions = true
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug (No Tests|Any CPU = Debug (No Tests|Any CPU
 		Debug (No Tests|Mixed Platforms = Debug (No Tests|Mixed Platforms


### PR DESCRIPTION
PopulationProcessor now correctly updates the population of a given colony.  Future updates need to account for colony and sector governors, atmospheric dust, radiation, and a better formula for decreasing populations.
