### PR TITLE
Set CultureInfo to en-US for whole application

### DIFF
--- a/Pulsar4X/Pulsar4X.CrossPlatformUI/Pulsar4XApplication.cs
+++ b/Pulsar4X/Pulsar4X.CrossPlatformUI/Pulsar4XApplication.cs
@@ -1,6 +1,7 @@
 ﻿using Eto;
 using Eto.Forms;
 using System;
+using System.Globalization;
 
 namespace Pulsar4X.CrossPlatformUI
 {
@@ -15,6 +16,10 @@ namespace Pulsar4X.CrossPlatformUI
 
         protected override void OnInitialized(EventArgs e)
         {
+            //Sets CultureInfo to en-US for the whole application;
+            CultureInfo.DefaultThreadCurrentCulture = CultureInfo.CreateSpecificCulture("en-US");
+            CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.CreateSpecificCulture("en-US");
+
             MainForm = new MainForm();
             base.OnInitialized(e);
 

--- a/Pulsar4X/Pulsar4X.ECSLib/Factories/ShipComponents/ComponentDesignAbility.cs
+++ b/Pulsar4X/Pulsar4X.ECSLib/Factories/ShipComponents/ComponentDesignAbility.cs
@@ -38,7 +38,7 @@ namespace Pulsar4X.ECSLib
                 input = MinValue;
             else if (input > MaxValue)
                 input = MaxValue;
-            Formula.ReplaceExpression(input.ToString(new System.Globalization.CultureInfo("en-US"))); //prevents it being reset to the default value on Evaluate;
+            Formula.ReplaceExpression(input.ToString()); //prevents it being reset to the default value on Evaluate;
             Formula.Evaluate();//force dependants to recalc.
         }
 

--- a/Pulsar4X/Pulsar4X.ECSLib/Factories/ShipComponents/ComponentDesignAbility.cs
+++ b/Pulsar4X/Pulsar4X.ECSLib/Factories/ShipComponents/ComponentDesignAbility.cs
@@ -38,7 +38,7 @@ namespace Pulsar4X.ECSLib
                 input = MinValue;
             else if (input > MaxValue)
                 input = MaxValue;
-            Formula.ReplaceExpression(input.ToString()); //prevents it being reset to the default value on Evaluate;
+            Formula.ReplaceExpression(input.ToString(new System.Globalization.CultureInfo("en-US"))); //prevents it being reset to the default value on Evaluate;
             Formula.Evaluate();//force dependants to recalc.
         }
 


### PR DESCRIPTION
ToString conversions, NCalc and maybe other functions throw exceptions, when decimal separator is comma instead of dot.