### PR TITLE
Allow lists to expand to whole screen in ColonyView

### DIFF
--- a/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/CargoView/CargoStorageView.xeto.cs
+++ b/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/CargoView/CargoStorageView.xeto.cs
@@ -7,7 +7,7 @@ using Pulsar4X.ViewModel;
 namespace Pulsar4X.CrossPlatformUI.Views.CargoView
 {
     
-    public class CargoStorageView : Scrollable
+    public class CargoStorageView : Panel
     {
         protected StackLayout CargoTypes;
         public CargoStorageView()

--- a/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/ColonyScreenView.xeto
+++ b/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/ColonyScreenView.xeto
@@ -5,38 +5,28 @@
   xmlns:c="clr-namespace:Pulsar4X.CrossPlatformUI.Views;assembly=Pulsar4X.CrossPlatformUI"
   xmlns:c2="clr-namespace:Pulsar4X.CrossPlatformUI.Views.CargoView;assembly=Pulsar4X.CrossPlatformUI"
   >
-  <TableLayout>
+  <TableLayout Padding="5,5,5,5" Spacing ="5,5">
     <TableRow>
       <ComboBox ID="ColonySelection"  />
     </TableRow>
-    <TableRow>
+    <TableRow ScaleHeight = "True">
       <TableLayout>
         <TableRow><Label Text="Facilites"/></TableRow>
-        <TableRow>
-          <c:GenericStackControl x:Name="FacilitysView" DataContext="{Binding FacilitesList}" />
-        </TableRow>      
+        <TableRow><c:GenericStackControl x:Name="FacilitysView" DataContext="{Binding FacilitesList}" /></TableRow>      
       </TableLayout>
       <TableLayout>
         <TableRow><Label Text ="Population"/></TableRow>
-        <TableRow> <GridView ID="PopDataGrid" /></TableRow>
-      </TableLayout>
-     
-      <TableLayout>
-        <TableRow> 
-          <Label Text="Mineral Deposits" /> 
-        </TableRow>
-        <TableRow>
-          <GridView ID="MineralDeposits"  />
-        </TableRow>
+        <TableRow><GridView ID="PopDataGrid" /></TableRow>
       </TableLayout>
       <TableLayout>
-        <TableRow>
-          <Label Text="Cargo Stockpile" />
-        </TableRow>
-        <TableRow>
-          <c2:CargoStorageView x:Name="CargoView"   />
-        </TableRow>
+        <TableRow><Label Text="Mineral Deposits"/></TableRow>
+        <TableRow><GridView ID="MineralDeposits"/></TableRow>
       </TableLayout>
+      <TableLayout>
+        <TableRow><Label Text="Cargo Stockpile"/></TableRow>
+        <TableRow><c2:CargoStorageView x:Name="CargoView"/></TableRow>
+      </TableLayout>
+      <TableLayout></TableLayout>
     </TableRow>
     <TableRow>
       <c:JobAbilityView x:Name="RefineryAbilityView" />

--- a/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/GenericStackControl.xeto
+++ b/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/GenericStackControl.xeto
@@ -3,5 +3,7 @@
   xmlns="http://schema.picoe.ca/eto.forms" 
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
   >
-  <StackLayout x:Name="Stack" />
+  <Scrollable>
+    <StackLayout x:Name="Stack" />
+  </Scrollable>
 </Panel>


### PR DESCRIPTION
The fix allows the Facilites, Population, MineralDeposits and CargoStockpile Lists to expand over the whole height of the window; This also enables correct Scrollbars in the Y-direction when resizing the Windows;

![scrollbar_after_resize_new](https://cloud.githubusercontent.com/assets/24638665/21955592/9f1b0276-da6e-11e6-83d8-4ef0c5fec3e8.PNG)

This required the following changes:
- Remove scrollable inheritage of CargoStorageView as it interfered with Table behavior
- Enable ScaleHeight of the List-Section in the ColonyView-Table
- the last column is always scaled, added dummy column in ColonyView; See also: https://github.com/picoe/Eto/wiki/TableLayout 
- Put Facilities (GenericStackControl) in a scrollable container

Also some visual improvements were added