### PR TITLE
Enables/Disables Time control, when a game is loaded

### DIFF
--- a/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/MainWindow.xeto
+++ b/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/MainWindow.xeto
@@ -8,7 +8,7 @@
   <TableLayout>
     <TableRow ScaleHeight="False">
       <TableCell>
-        <c:TimeControlView  DataContext="{Binding TimeControl}" />
+        <c:TimeControlView  ID ="TimeControlV" DataContext="{Binding TimeControl}" Enabled ="False" />
         <!--
         <StackLayout Orientation="Horizontal" x:Name="adv_buttons" Padding="10,5,5,5" VerticalContentAlignment="Center">
           <Panel Padding="5,0,10,0">

--- a/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/MainWindow.xeto.cs
+++ b/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/MainWindow.xeto.cs
@@ -9,8 +9,11 @@ namespace Pulsar4X.CrossPlatformUI.Views {
     public class MainWindow : Panel {
         #region Form Controls
         protected StackLayout TopButtonBar;
-
         protected StackLayout adv_buttons;
+        protected DropDown dd_subpulse;
+        protected TabControl view_tabs;
+        protected TimeControlView TimeControlV;
+
         #region Advance Time Buttons
         protected Button btn_time_5sec;
         protected Button btn_time_30sec;
@@ -24,18 +27,38 @@ namespace Pulsar4X.CrossPlatformUI.Views {
         protected Button btn_time_5day;
         protected Button btn_time_30day;
         #endregion
-
-        protected DropDown dd_subpulse;
-        protected TabControl view_tabs;
         #endregion
 
-        private GameVM _game;
+        private GameVM _gameVM;
+
+        #region Constructors
+        /// <summary>
+        /// Initializes a new instance of the MainWindow view
+        /// </summary>
         public MainWindow(GameVM game) {
-            _game = game;
-            DataContext = _game;
+            _gameVM = game;
+            DataContext = _gameVM;
             XamlReader.Load(this);
+            _gameVM.PropertyChanged += _gameVM_PropertyChanged;
         }
-        
+        #endregion
+
+        #region Events
+        /// <summary>
+        /// Enables/Disables Timing control, when game has loaded/unloaded;
+        /// </summary>
+        private void _gameVM_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == "HasGame")
+            {
+                TimeControlV.Enabled = _gameVM.HasGame;          
+            }
+        }
+        #endregion
+
+        /// <summary>
+        /// Adds additional Views as Panels to the TabPage
+        /// </summary>
         public void AddOrSelectTabPanel(string title, Container c, bool activate = true, bool force_new = false) {
             if (!force_new) {
                 foreach (TabPage p in view_tabs.Pages) {

--- a/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/TimeControlView.xeto
+++ b/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/TimeControlView.xeto
@@ -4,12 +4,14 @@
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
   >
 
-  <TableLayout >
+  <TableLayout Padding ="5,5,5,5" >
     <TableRow>
 	    <Label Text="Tick Length" />
       <NumericUpDown Value ="{Binding TickLength}"/>
+      <Label Text="  " Enabled ="False" />
       <Label Text="Tick Multiplier" />
       <NumericUpDown Value ="{Binding TickMultiplier}"/>
+      <Label Text="  " Enabled ="False" />
       <Button Command="{Binding PausePlayCMD}"  Text="||>" />
       <Button Command="{Binding TimeStepCMD}" Text="Step" />
       <TableCell></TableCell>
@@ -17,8 +19,10 @@
     <TableRow >
 	    <Label Text="Tick Frequency" />
       <NumericUpDown Value ="{Binding TickFreq}" />
+      <Label Text="  " Enabled ="False" />
       <Label Text="Date: " />
       <Label Text="{Binding CurrentGameDate}" />
+      <Label Text="  " Enabled ="False" />
       <Label Text="LastProcessingTime: " />
       <Label Text="{Binding LastTickLen}" />
     </TableRow>

--- a/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/TimeControlView.xeto
+++ b/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/TimeControlView.xeto
@@ -6,11 +6,11 @@
 
   <TableLayout Padding ="5,5,5,5" >
     <TableRow>
-	    <Label Text="Tick Length" />
-      <NumericUpDown Value ="{Binding TickLength}"/>
+	    <Label Text="Tick Length [s]" />
+      <NumericUpDown Value ="{Binding TickLength}" MinValue = "1"/>
       <Label Text="  " Enabled ="False" />
       <Label Text="Tick Multiplier" />
-      <NumericUpDown Value ="{Binding TickMultiplier}"/>
+      <NumericUpDown Value ="{Binding TickMultiplier}" MinValue = "1"/>
       <Label Text="  " Enabled ="False" />
       <Button Command="{Binding PausePlayCMD}"  Text="||>" />
       <Button Command="{Binding TimeStepCMD}" Text="Step" />
@@ -18,7 +18,7 @@
     </TableRow>
     <TableRow >
 	    <Label Text="Tick Frequency" />
-      <NumericUpDown Value ="{Binding TickFreq}" />
+      <NumericUpDown Value ="{Binding TickFreq}" MinValue = "1" />
       <Label Text="  " Enabled ="False" />
       <Label Text="Date: " />
       <Label Text="{Binding CurrentGameDate}" />


### PR DESCRIPTION
The TimeControl starts disabled on startup and enables when a game is loaded/started.
Addition to constructor:
> _gameVM.PropertyChanged += _gameVM_PropertyChanged;

and function that enables/disables the TimeControlView
>        private void _gameVM_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
>        {
>            if (e.PropertyName == "HasGame")
>            {
>                TimeControlV.Enabled = _gameVM.HasGame;          
>            }
>        }

Other additions:
* Commenting (I hope this is meaningful enough)
* Minor optical enhancements of Timingcontrol
* Impose constraints on TimingControl's NumericUpDowns