### PR TITLE
Enable Textlabel stacking in SystemView

### DIFF
--- a/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/SystemMap_DrawableView.xeto.cs
+++ b/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/SystemMap_DrawableView.xeto.cs
@@ -113,7 +113,7 @@ namespace Pulsar4X.CrossPlatformUI.Views
             string lastDrawTime = stopwatch.ElapsedMilliseconds.ToString();
             stopwatch.Reset();
             Font font = new Font(FontFamilies.Fantasy, 8);
-            Color color = new Color(Colors.Black);
+            Color color = new Color(Colors.White);
             PointF loc = new PointF(0, 0);
             e.Graphics.DrawText(font, color, loc, lastDrawTime);
         }

--- a/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/SystemView/Camera.cs
+++ b/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/SystemView/Camera.cs
@@ -49,6 +49,50 @@ namespace Pulsar4X.CrossPlatformUI.Views
         }
 
         /// <summary>
+        /// returns the worldCoordinate of a given View Coordinate 
+        /// </summary>
+        /// <param name="viewCoordinate"></param>
+        /// <returns></returns>
+        public Point WorldCoordinate(PointF viewCoordinate)
+        {
+            Point worldCoord = (Point)((viewCoordinate - ViewPortCenter) / (ZoomLevel));
+            return worldCoord;
+        }
+
+        /// <summary>
+        /// returns the worldCoordinate of a given View Coordinate 
+        /// </summary>
+        /// <param name="viewCoordinate"></param>
+        /// <returns></returns>
+        public Point WorldCoordinate(Vector4 viewCoordinate)
+        {
+            PointF coord = new PointF((float) viewCoordinate.X, (float) viewCoordinate.Y);
+            return WorldCoordinate(coord);
+        }
+
+        /// <summary>
+        /// Returns the size of an object in view-Coordinates
+        /// </summary>
+        /// <param name="worldSize"></param>
+        /// <returns></returns>
+        public SizeF ViewSize(SizeF worldSize)
+        {
+            SizeF viewSize = worldSize * ZoomLevel;
+            return viewSize;
+        }
+
+        /// <summary>
+        /// Returns the size of an object in world-Coordinates
+        /// </summary>
+        /// <param name="viewSize"></param>
+        /// <returns></returns>
+        public SizeF WorldSize(SizeF viewSize)
+        {
+            SizeF WorldSize = viewSize / ZoomLevel;
+            return WorldSize;
+        }
+
+        /// <summary>
         /// Offset the position of the camare i.e. Pan in world units.
         /// <param name="offset">Pans the camera relative to offset</param>
         /// </summary>
@@ -85,12 +129,15 @@ namespace Pulsar4X.CrossPlatformUI.Views
 
         }
 
+        /// <summary>
+        /// Returns the translation matrix for a world position, relative to the camera position
+        /// </summary>
+        /// <param name="position">Position in World Units</param>
+        /// <returns></returns>
         public IMatrix GetViewProjectionMatrix(PointF position)
         {
             var transformMatrix = Matrix.Create();
-            transformMatrix.Translate(ViewCoordinate(_cameraWorldPosition));
-            position *= ZoomLevel;
-            transformMatrix.Translate(position);
+            transformMatrix.Translate(ViewCoordinate(_cameraWorldPosition + position));
             return transformMatrix;
         }
     }

--- a/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/SystemView/IconCollection.cs
+++ b/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/SystemView/IconCollection.cs
@@ -7,39 +7,116 @@ namespace Pulsar4X.CrossPlatformUI.Views
 {
     internal class IconCollection
     {
-        public List<IconBase> Icons { get; } = new List<IconBase>();
+        //Main dictionaries for storing Icons
+        //The Guid represents the entity, the Icon is created for
+        public List<OrbitRing> OrbitList { get; } = new List<OrbitRing>();
+        public List<TextIcon> TextIconList { get; } = new List<TextIcon>();
+        public List<EntityIcon> EntityList { get; } = new List<EntityIcon>();
+
+
         public Dictionary<Guid, EntityIcon> IconDict { get; } = new Dictionary<Guid, EntityIcon> ();
+
+        /// <summary>
+        /// Constructs an IconCollection
+        /// </summary>
         public IconCollection()
         {
         }
 
+        /// <summary>
+        /// Initializes the IconCollection
+        /// Creates Orbitrings, TextIcons and Entityicons and adds them to Collection
+        /// </summary>
+        /// <param name="entities"></param>
+        /// <param name="camera"></param>
         public void Init(IEnumerable<Entity> entities, Camera2dv2 camera)
         {
-            Icons.Clear();
+            System.Diagnostics.Debug.WriteLine("Init called");
             IconDict.Clear();
+            OrbitList.Clear();
+            TextIconList.Clear();
+            EntityList.Clear();
+
             foreach (var item in entities)
             {
                 if (item.HasDataBlob<OrbitDB>() && item.GetDataBlob<OrbitDB>().Parent != null)
                 {
                     OrbitRing ring = new OrbitRing(item, camera);
-
-                    Icons.Add(ring);
+                    OrbitList.Add(ring);
                 }
                 if (item.HasDataBlob<NameDB>())
-                    Icons.Add(new TextIcon(item, camera));
+                {
+                    TextIconList.Add(new TextIcon(item, camera));
+                }
+
 
                 EntityIcon entIcon = new EntityIcon(item, camera);
-                Icons.Add(entIcon);
+                EntityList.Add(entIcon);
+
+
                 IconDict.Add(item.Guid, entIcon);
             }
         }
 
+        /// <summary>
+        /// Distributes the TextIcons, when they are overlapping
+        /// </summary>
+        public void TextIconsDistribute()
+        {
+            List<Rectangle> occupiedPosition = new List<Rectangle>();
+            IComparer<Rectangle> byViewPos = new ByViewPosition();
+
+            foreach (var item in TextIconList)
+            {
+                item.ViewOffset = item.DefaultViewOffset;
+            }
+
+            //Placement happens bottom to top, left to right
+            //Each newly placed Texticon is compared to only the Texticons that are placed above its position
+            //Therefore a sorted list of the occupied Positions is maintained
+            TextIconList.Sort();
+            occupiedPosition.Add(TextIconList[0].ViewDisplayRect);
+            for (int i = 1; i < TextIconList.Count; i++)
+            {
+                var lowestPosIndex = occupiedPosition.BinarySearch(TextIconList[i].ViewDisplayRect + new Point(0,(int)TextIconList[i].ViewNameSize.Height) , byViewPos);
+                if (lowestPosIndex < 0) lowestPosIndex = ~lowestPosIndex;
+                
+                for (int j = lowestPosIndex; j < occupiedPosition.Count; j++)
+                {
+                    if (TextIconList[i].ViewDisplayRect.Intersects(occupiedPosition[j]))
+                    {
+                        TextIconList[i].ViewOffset -= new PointF(0,  TextIconList[i].ViewDisplayRect.Bottom - occupiedPosition[j].Top);
+                    }
+                }
+                //Inserts the new label sorted
+                var InsertIndex = occupiedPosition.BinarySearch(TextIconList[i].ViewDisplayRect, byViewPos);
+                if (InsertIndex < 0) InsertIndex = ~InsertIndex;
+                occupiedPosition.Insert(InsertIndex, TextIconList[i].ViewDisplayRect);
+            }
+
+
+        }
+
+        /// <summary>
+        /// Draws all Items in _ItemCollection
+        /// In the following order:
+        ///     Orbitrings
+        ///     EntitySymbols
+        ///     TextLabels
+        /// </summary>
+        /// <param name="g"></param>
         public void DrawMe(Graphics g)
         {
-            foreach (var item in Icons)
+            foreach( var item in OrbitList)
+                item.DrawMe(g);
+            foreach (var item in EntityList)
+                item.DrawMe(g);
+
+            TextIconsDistribute();
+            foreach (var item in TextIconList)
             {
                 item.DrawMe(g);
-            }
+            }            
         }
     }
 
@@ -47,8 +124,26 @@ namespace Pulsar4X.CrossPlatformUI.Views
     {
         //sets the size of the icons
         float Scale { get; set; }
-
         void DrawMe(Graphics g);
     }
 
+
+    /// <summary>
+    /// IComparer for the Texticonrectangles (or any other rectancle)
+    /// Sorts Bottom to top, left to right
+    /// </summary>
+    internal class ByViewPosition : IComparer<Rectangle>
+    {
+        public int Compare(Rectangle r1, Rectangle r2)
+        {
+            if (r1.Bottom > r2.Bottom) return -1;
+            else if (r1.Bottom < r2.Bottom) return 1;
+            else
+            {
+                if (r1.Left > r2.Left) return -1;
+                else if (r1.Left < r2.Left) return 1;
+                else return 0;
+            }
+        }
+    }
 }

--- a/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/SystemView/IconCollection.cs
+++ b/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/SystemView/IconCollection.cs
@@ -31,7 +31,6 @@ namespace Pulsar4X.CrossPlatformUI.Views
         /// <param name="camera"></param>
         public void Init(IEnumerable<Entity> entities, Camera2dv2 camera)
         {
-            System.Diagnostics.Debug.WriteLine("Init called");
             IconDict.Clear();
             OrbitList.Clear();
             TextIconList.Clear();

--- a/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/SystemView/TextIcon.cs
+++ b/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/SystemView/TextIcon.cs
@@ -1,42 +1,76 @@
 ﻿using Pulsar4X.ECSLib;
+using System.Collections.Generic;
 using Eto.Drawing;
+using System;
 
 namespace Pulsar4X.CrossPlatformUI.Views
 {
-    internal class TextIcon : IconBase
+    internal class TextIcon : IconBase, IComparable<TextIcon>
     {
-
         public float Scale { get; set; } = 8;
-        Font font { get; set; }
-        Color color { get; set; }
-        private float Zoom { get { return _camera.ZoomLevel; } }
-        private Size ViewSize { get { return _camera._viewPort.Size; } }
-        private PositionDB _starSysPosition;
-        private Camera2dv2 _camera;
-        private string _name;
+        public Font font { get; set; }
+        public Color color { get; set; }
+        public int padding { get; set; } = 1;
 
+        public PointF ViewPosition { get { return _camera.ViewCoordinate(new PointF((float)worldPosition.X, (float)worldPosition.Y)) + ViewOffset; } }
+        public SizeF ViewNameSize { get { return new SizeF(font.Size * name.Length + padding, font.LineHeight + padding); } }
+        public PointF DefaultViewOffset { get; set; }
+        public PointF ViewOffset { get; set; } = new PointF(0, 0);
+        public Rectangle ViewDisplayRect { get { return new Rectangle((Point)ViewPosition, (Size)ViewNameSize); } }
+
+        public PositionDB worldPosition { get; }
+
+        public string name { get; }
+
+        private Camera2dv2 _camera;
+
+        /// <summary>
+        /// Constructor for a new Texticon
+        /// </summary>
+        /// <param name="entity">The Entity that stores the textstring and position</param>
+        /// <param name="camera">The Cameraobject where the Texticon is drawn</param>
         public TextIcon(Entity entity, Camera2dv2 camera)
         {
             _camera = camera;
-            _starSysPosition = entity.GetDataBlob<PositionDB>();
-            _name = entity.GetDataBlob<NameDB>().DefaultName;
+            worldPosition = entity.GetDataBlob<PositionDB>();
+            name = entity.GetDataBlob<NameDB>().DefaultName;
             font = new Font(FontFamilies.Fantasy, Scale);
-            color = new Color(Colors.Black);
+            color = new Color(Colors.White);
+            DefaultViewOffset = new PointF(8, -font.LineHeight/2);
         }
 
+
+        /// <summary>
+        /// Default comparer, based on worldposition.
+        /// Sorts Bottom to top, left to right
+        /// </summary>
+        /// <param name="compareIcon"></param>
+        /// <returns></returns>
+        public int CompareTo(TextIcon compareIcon)
+        {
+            if (this.worldPosition.Y > compareIcon.worldPosition.Y) return -1;
+            else if (this.worldPosition.Y < compareIcon.worldPosition.Y) return 1;
+            else
+            {
+                if (this.worldPosition.X > compareIcon.worldPosition.X) return 1;
+                else if (this.worldPosition.X < compareIcon.worldPosition.X) return -1;
+                else return 0;
+            }
+        }
+
+        /// <summary>
+        /// Draws the Name of the Item
+        /// </summary>
+        /// <param name="g"></param>
         public void DrawMe(Graphics g)
         {
-
             g.SaveTransform();
-            //g.MultiplyTransform(PositionTransform());
-            IMatrix cameraOffset = _camera.GetViewProjectionMatrix(new PointF((float)_starSysPosition.X, (float)_starSysPosition.Y));
-            //apply the camera offset
+            IMatrix cameraOffset = _camera.GetViewProjectionMatrix(new PointF((float)worldPosition.X, (float)worldPosition.Y));
             g.MultiplyTransform(cameraOffset);
-
-            g.DrawText(font, color, (float)_starSysPosition.X, (float)_starSysPosition.Y, _name);
+            g.TranslateTransform(ViewOffset);
+            g.DrawText(font, color, (float)worldPosition.X, (float)worldPosition.Y, name);
 
             g.RestoreTransform();
         }
     }
-
 }


### PR DESCRIPTION
Allows stacking of labels in the System view:
![stackinglabels multiple ships](https://cloud.githubusercontent.com/assets/24638665/22856646/a7c8a314-f095-11e6-8b6c-7f16cf310002.PNG)
![stackinglabels](https://cloud.githubusercontent.com/assets/24638665/22856647/a7cb2e90-f095-11e6-9f5a-eb745d24a06b.PNG)

Changes to camera-class:
- Create functions to allow Coordinate changes from View-Coordinates to World-Coordinates (and vice versa)
- Changes to GetViewProjectionMatrix gets rid of not necessary matrix translation

Changes in IconCollection:
- Split single list of IconBase into three Lists to allow more distinguished handling
- Create function that allows the stacking of the labels (without doing a NxN comparison every frame update)
- Create IComparer for sorting the TextLabels

Changes in TextIcon:
- Created default-comparer based on World-Position
- Added a bunch more variables for the stacking function in IconCollection

Reminder: There is a little odd behavior that seemingly randomizes the stacked Textsequence when Texts are in the same position. I will have to look into that...
