### PR TITLE
SystemView: Add quantifier to TextLabels if at same position

### DIFF
--- a/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/SystemView/IconCollection.cs
+++ b/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/SystemView/IconCollection.cs
@@ -70,10 +70,29 @@ namespace Pulsar4X.CrossPlatformUI.Views
                 item.ViewOffset = item.DefaultViewOffset;
             }
 
+            //Consolidate TextIcons that share the same position and name
+            TextIconList.Sort();
+            int ListLength = TextIconList.Count;
+            int TextIconQuantity = 1;
+            for (int i = 1; i < ListLength; i++)
+            {
+                if (TextIconList[i - 1].CompareTo(TextIconList[i]) == 0)
+                {
+                    TextIconQuantity++;
+                    TextIconList.RemoveAt(i);
+                    i--;
+                    ListLength--;
+                }
+                else if (TextIconQuantity > 1)
+                {
+                    TextIconList[i - 1].name += " x" + TextIconQuantity;
+                    TextIconQuantity = 1;
+                }
+            }
+
             //Placement happens bottom to top, left to right
             //Each newly placed Texticon is compared to only the Texticons that are placed above its position
             //Therefore a sorted list of the occupied Positions is maintained
-            TextIconList.Sort();
             occupiedPosition.Add(TextIconList[0].ViewDisplayRect);
             for (int i = 1; i < TextIconList.Count; i++)
             {

--- a/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/SystemView/TextIcon.cs
+++ b/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/SystemView/TextIcon.cs
@@ -54,7 +54,7 @@ namespace Pulsar4X.CrossPlatformUI.Views
             {
                 if (this.worldPosition.X > compareIcon.worldPosition.X) return 1;
                 else if (this.worldPosition.X < compareIcon.worldPosition.X) return -1;
-                else return 0;
+                else return this.name.CompareTo(compareIcon.name);
             }
         }
 

--- a/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/SystemView/TextIcon.cs
+++ b/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/SystemView/TextIcon.cs
@@ -20,7 +20,7 @@ namespace Pulsar4X.CrossPlatformUI.Views
 
         public PositionDB worldPosition { get; }
 
-        public string name { get; }
+        public string name { get; set; }
 
         private Camera2dv2 _camera;
 
@@ -42,7 +42,7 @@ namespace Pulsar4X.CrossPlatformUI.Views
 
         /// <summary>
         /// Default comparer, based on worldposition.
-        /// Sorts Bottom to top, left to right
+        /// Sorts Bottom to top, left to right, then alphabetically
         /// </summary>
         /// <param name="compareIcon"></param>
         /// <returns></returns>
@@ -54,7 +54,7 @@ namespace Pulsar4X.CrossPlatformUI.Views
             {
                 if (this.worldPosition.X > compareIcon.worldPosition.X) return 1;
                 else if (this.worldPosition.X < compareIcon.worldPosition.X) return -1;
-                else return this.name.CompareTo(compareIcon.name);
+                else return -this.name.CompareTo(compareIcon.name);
             }
         }
 


### PR DESCRIPTION
Adds a quantifier to the Textlabels if they share exactly the same world-position.

Without quantifier:
![namequantities_old](https://cloud.githubusercontent.com/assets/24638665/22900263/06147bc0-f22e-11e6-822c-dd2f52388964.PNG)

With quantifier:
![namequantities](https://cloud.githubusercontent.com/assets/24638665/22900269/0b683f08-f22e-11e6-96ea-910dbe5562e3.PNG)

Also sorts the texticons Alphabetically