### PR TITLE
Fixed rounding in MaxSpeedCalc().

### DIFF
--- a/Pulsar4X/Pulsar4X.ECSLib/Processors/TranslationMoveProcessor.cs
+++ b/Pulsar4X/Pulsar4X.ECSLib/Processors/TranslationMoveProcessor.cs
@@ -44,7 +44,7 @@ namespace Pulsar4X.ECSLib
             // From Aurora4x wiki:  Speed = (Total Engine Power / Total Class Size in HS) * 1000 km/s
             // 1 HS = 50 tons
 
-            return (int)(power / tonage) * 20;
+            return (int)((power / tonage) * 20);
         }
     }
 


### PR DESCRIPTION
Note: This doesn't fix the failing TestShipCreation() test. Just makes it fail in a fashion that isn't so puzzling.