### PR TITLE
Bugfix/experimental/ship max speed recalculation

### DIFF
--- a/Pulsar4X/Pulsar4X.ECSLib/Processors/ShipAndColonyInfoProcessor.cs
+++ b/Pulsar4X/Pulsar4X.ECSLib/Processors/ShipAndColonyInfoProcessor.cs
@@ -35,7 +35,7 @@ namespace Pulsar4X.ECSLib
             if (shipInfo.Tonnage != totalTonnage)
             {
                 shipInfo.Tonnage = totalTonnage;
-                //ShipMovementProcessor.CalcMaxSpeed(shipEntity);
+                PropulsionCalcs.CalcMaxSpeed(shipEntity); 
             }
             shipInfo.InternalHTK = totalHTK;
             MassVolumeDB mvDB = shipEntity.GetDataBlob<MassVolumeDB>();


### PR DESCRIPTION
This fixes the failing test, but the overall way the recalculations work, anything that triggers recalculations of tonnage and HTK will trigger maximum speed recalculations. Something to fix/optimize later, I guess.