### PR TITLE
Makes ComponentDesignView prettier

### DIFF
--- a/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/AbilitySelectionList.xeto
+++ b/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/AbilitySelectionList.xeto
@@ -3,10 +3,10 @@
   xmlns="http://schema.picoe.ca/eto.forms" 
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
   >
-  <TableLayout>
+  <TableLayout  Padding="5,5" Spacing ="5,5">
     <TableRow>
       <Label ID="AbilityName" Text="{Binding Name}" />
-      <ComboBox  ID="AbilitySelection"  DataContext="{Binding TechList}" />
+      <ComboBox  ID="AbilitySelection"  DataContext="{Binding TechList}"  Width="200"/>
     </TableRow>
     
   </TableLayout>

--- a/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/ChainedSlidersControl.xeto.cs
+++ b/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/ChainedSlidersControl.xeto.cs
@@ -18,9 +18,9 @@ namespace Pulsar4X.CrossPlatformUI.Views
         {
             DataContext = chainedSliders;
 
-            foreach (var item in chainedSliders.Sliders)
+            foreach (var item in chainedSliders.SliderVMs)
             {
-                MinMaxSlider mms = new MinMaxSlider() { DataContext = item };
+                MinMaxSlider mms = new MinMaxSlider(item);
                 SlidersStack.Items.Add(mms);
             }
         }

--- a/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/ComponentDesignView.xeto
+++ b/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/ComponentDesignView.xeto
@@ -3,7 +3,7 @@
   xmlns="http://schema.picoe.ca/eto.forms" 
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
   >
-  <TableLayout>
+  <TableLayout Spacing ="2,2">
     <TableRow>
       <ComboBox ID="ComponentSelection" DataContext="{Binding ComponentTypes}" />
     </TableRow>

--- a/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/ComponentDesignView.xeto.cs
+++ b/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/ComponentDesignView.xeto.cs
@@ -54,8 +54,7 @@ namespace Pulsar4X.CrossPlatformUI.Views
                         AbilitysLayout.Items.Add(asl);
                         break;
                     case GuiHint.GuiSelectionMaxMin:
-                        MinMaxSlider mms = new MinMaxSlider() {};
-                        mms.DataContext = componentAbilityVM.MinMaxSlider;
+                        MinMaxSlider mms = new MinMaxSlider(componentAbilityVM.minMaxSliderVM) {};
                         AbilitysLayout.Items.Add(mms);
                         break;
                 }

--- a/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/MinMaxSlider.xeto
+++ b/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/MinMaxSlider.xeto
@@ -4,33 +4,25 @@
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
   >
 
-  <TableLayout>
+  <TableLayout Padding="5,5" Spacing ="5,5">
     <TableRow>
-
       <Label Text="{Binding Name}" />
-
+      <Label Text="{Binding MinValue}"  />
       <Slider ID="Slider"
+       Width ="120"
        Value="{Binding SliderValue}"
        MinValue="{Binding SliderMinValue}"
        MaxValue="{Binding SliderMaxValue}"
-  
        SnapToTick="{Binding StrictStepValue}"  
        Enabled="{Binding IsUnLocked}"
       />
-    </TableRow>
-    <TableRow>
+      <Label Text="{Binding MaxValue}" />
       <CheckBox Visible="{Binding IsLockable}" Checked="{Binding IsLocked}"/>
-      <TableLayout>
-      <TableRow>
-      <Label Text="{Binding MinValue}"  />
       <NumericUpDown ID="NumericUpDown"  
         Value ="{Binding Value}"
         MaxValue ="{Binding MaxValue}"              
         MinValue ="{Binding MinValue}"
         Enabled="{Binding IsUnLocked}"/>
-      <Label Text="{Binding MaxValue}" />
-      </TableRow>
-      </TableLayout>
     </TableRow>
   </TableLayout>
 	

--- a/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/MinMaxSlider.xeto.cs
+++ b/Pulsar4X/Pulsar4X.CrossPlatformUI/Views/MinMaxSlider.xeto.cs
@@ -10,11 +10,19 @@ namespace Pulsar4X.CrossPlatformUI.Views
         protected Slider Slider { get; set; }
         protected NumericUpDown NumericUpDown { get; set; }
 
+        private MinMaxSliderVM _minMaxSLiderVM;
+
         public MinMaxSlider()
         {
             XamlReader.Load(this);           
             NumericUpDown.DecimalPlaces = 4;
             DataContextChanged += MinMaxSlider_DataContextChanged;
+        }
+
+        public MinMaxSlider (MinMaxSliderVM viewModel) : this()
+        {
+            _minMaxSLiderVM = viewModel;
+            DataContext = viewModel;
         }
 
         private void MinMaxSlider_DataContextChanged(object sender, System.EventArgs e)

--- a/Pulsar4X/ViewModelLib/ViewModels/ComponentDesignVM.cs
+++ b/Pulsar4X/ViewModelLib/ViewModels/ComponentDesignVM.cs
@@ -138,7 +138,7 @@ namespace Pulsar4X.ViewModel
 
         public GuiHint GuiHint { get { return _designAbility.GuiHint; }}
         
-        public MinMaxSliderVM MinMaxSlider { get; set; }
+        public MinMaxSliderVM minMaxSliderVM { get; set; }
         
 
 
@@ -163,18 +163,18 @@ namespace Pulsar4X.ViewModel
                     break;
                 case GuiHint.GuiSelectionMaxMin:
                     {
-                        MinMaxSlider = new MinMaxSliderVM();
+                        minMaxSliderVM = new MinMaxSliderVM();
 
                         designAbility.SetMax();
                         designAbility.SetMin();
                         designAbility.SetValue();
                         designAbility.SetStep();
-                        MinMaxSlider.Name = Name;
-                        MinMaxSlider.MaxValue = MaxValue;
-                        MinMaxSlider.MinValue = MinValue;
-                        MinMaxSlider.StepValue = StepValue;
-                        MinMaxSlider.Value = Value; //.PreLoadedValue = Value; //hack due to eto bug. MinMaxSlider.Value = Value; 
-                        MinMaxSlider.PropertyChanged += MinMaxSlider_PropertyChanged;
+                        minMaxSliderVM.Name = Name;
+                        minMaxSliderVM.MaxValue = MaxValue;
+                        minMaxSliderVM.MinValue = MinValue;
+                        minMaxSliderVM.StepValue = StepValue;
+                        minMaxSliderVM.Value = Value; //.PreLoadedValue = Value; //hack due to eto bug. MinMaxSlider.Value = Value; 
+                        minMaxSliderVM.PropertyChanged += MinMaxSlider_PropertyChanged;
 
                     }
                     break;
@@ -189,7 +189,7 @@ namespace Pulsar4X.ViewModel
 
         void MinMaxSlider_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            _designAbility.SetValueFromInput(MinMaxSlider.Value);
+            _designAbility.SetValueFromInput(minMaxSliderVM.Value);
             _parentDesignVM.Refresh();
         }
 

--- a/Pulsar4X/ViewModelLib/ViewModels/MinMaxSliderVM.cs
+++ b/Pulsar4X/ViewModelLib/ViewModels/MinMaxSliderVM.cs
@@ -139,18 +139,18 @@ namespace Pulsar4X.ViewModel
         public double MaxValue { get { return _maxValue; } set
             {
                 _maxValue = value;
-                foreach (var slider in Sliders)
+                foreach (var slider in SliderVMs)
                 {
                     slider.MaxValue = value;
                 }
                 OnPropertyChanged(); }}
 
-        public List<ChainedSliderVM> Sliders { get; } = new List<ChainedSliderVM>();
+        public List<ChainedSliderVM> SliderVMs { get; } = new List<ChainedSliderVM>();
         
         public ChainedSliders(List<ChainedSliderVM> listOfSliders)
         {
-            Sliders.AddRange(listOfSliders);
-            foreach (var slider in Sliders)
+            SliderVMs.AddRange(listOfSliders);
+            foreach (var slider in SliderVMs)
             {
                 slider.MaxValue = MaxValue;
                 slider.ValueChanged += Slider_ValueChanged;
@@ -195,7 +195,7 @@ namespace Pulsar4X.ViewModel
             get
             {
                 double value = 0;
-                foreach (var slider in Sliders)
+                foreach (var slider in SliderVMs)
                 {
                     value += slider.Value;
                 }
@@ -217,9 +217,9 @@ namespace Pulsar4X.ViewModel
             }
         }
 
-        private List<ChainedSliderVM> UnlockedSliders { get { return Sliders.Where(T => !T.IsLocked).ToList(); } } 
+        private List<ChainedSliderVM> UnlockedSliders { get { return SliderVMs.Where(T => !T.IsLocked).ToList(); } } 
 
-        private List<ChainedSliderVM> LockedSliders { get { return Sliders.Where(T => T.IsLocked).ToList(); } }
+        private List<ChainedSliderVM> LockedSliders { get { return SliderVMs.Where(T => T.IsLocked).ToList(); } }
 
 
         public event PropertyChangedEventHandler PropertyChanged;


### PR DESCRIPTION
Changes the appearance of MinMaxSlider and AbilitySelectionList.
![componentdesign](https://user-images.githubusercontent.com/24638665/27517471-c0dd8cd8-59cd-11e7-9ddb-cf05f888f964.PNG)
![missileview](https://user-images.githubusercontent.com/24638665/27517475-c38e3a18-59cd-11e7-8df0-955d5ce1e7f1.PNG)
I am not fully happy with this as the Vertical arrangement of the Controls is not in sync. But this requires to change the elements to a DataRow, but a DataRow does not have a DataContext...

Also moves the Datacontext assignment of the MinMaxSlider inside the MinMaxSlider Constructor instead of the external assignment via ComponentDesignView

Also if anyone wants to know how the MinMaxSlider and MinMaxSliderVM are connected with each other:
![minmaxslideruml](https://user-images.githubusercontent.com/24638665/27517501-f50eb090-59cd-11e7-8acf-e0bd27971a6c.PNG)
