### PR TITLE
Cargo space rework - CargoDefinitionsLibrary

### DIFF
--- a/Pulsar4X/Pulsar4X.ECSLib/ComponentFeatureSets/CargoStorage/CargoCapacityCheckResult.cs
+++ b/Pulsar4X/Pulsar4X.ECSLib/ComponentFeatureSets/CargoStorage/CargoCapacityCheckResult.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Pulsar4X.ECSLib.ComponentFeatureSets.CargoStorage
+{
+    public class CargoCapacityCheckResult
+    {
+        public Guid IdOfItemChecked { get; private set; }
+        public long FreeCapacityItem { get; private set; }
+        public long FreeCapacityKg { get; private set; }
+
+        public CargoCapacityCheckResult(Guid item, long count, long kg)
+        {
+            IdOfItemChecked = item;
+            FreeCapacityItem = count;
+            FreeCapacityKg = kg;
+        }
+    }
+}

--- a/Pulsar4X/Pulsar4X.ECSLib/ComponentFeatureSets/CargoStorage/CargoDefinitionsLibrary.cs
+++ b/Pulsar4X/Pulsar4X.ECSLib/ComponentFeatureSets/CargoStorage/CargoDefinitionsLibrary.cs
@@ -1,0 +1,204 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Pulsar4X.ECSLib.ComponentFeatureSets.CargoStorage
+{
+    public interface ICargoDefinitionsLibrary
+    {
+        void LoadDefinitions(List<MineralSD> minerals,
+            List<ProcessedMaterialSD> processedMaterials,
+            List<ICargoable> otherCargo);
+
+        void LoadMineralDefinitions(List<MineralSD> minerals);
+        void LoadMaterialsDefinitions(List<ProcessedMaterialSD> materials);
+        void LoadOtherDefinitions(List<ICargoable> otherCargo);
+
+        Dictionary<Guid, ICargoable> GetAll();
+
+        object GetAny(Guid id);
+
+        bool IsOther(Guid id);
+        ICargoable GetOther(string nameOfCargo);
+        ICargoable GetOther(Guid guidOfCargo);
+
+        bool IsMineral(Guid id);
+        MineralSD GetMineral(string name);
+        MineralSD GetMineral(Guid guid);
+        Dictionary<Guid, MineralSD> GetMinerals();
+        List<MineralSD> GetMineralsList();
+
+        bool IsMaterial(Guid id);
+        ProcessedMaterialSD GetMaterial(string name);
+        ProcessedMaterialSD GetMaterial(Guid guid);
+        Dictionary<Guid, ProcessedMaterialSD> GetMaterials();
+        List<ProcessedMaterialSD> GetMaterialsList();
+    }
+
+    public class CargoDefinitionsLibrary : ICargoDefinitionsLibrary
+    {
+        private Dictionary<Guid, ICargoable> _definitions;
+        private Dictionary<Guid, MineralSD> _minerals;
+        private Dictionary<Guid, ProcessedMaterialSD> _processedMaterials;
+
+        public CargoDefinitionsLibrary() : this(new List<MineralSD>(),
+            new List<ProcessedMaterialSD>(),
+            new List<ICargoable>())
+        {
+        }
+
+        public CargoDefinitionsLibrary(List<MineralSD> minerals,
+            List<ProcessedMaterialSD> processedMaterials,
+            List<ICargoable> otherCargo)
+        {
+            _definitions = new Dictionary<Guid, ICargoable>();
+            _minerals = new Dictionary<Guid, MineralSD>();
+            _processedMaterials = new Dictionary<Guid, ProcessedMaterialSD>();
+
+            LoadDefinitions(minerals, processedMaterials, otherCargo);
+        }
+
+        
+        public void LoadDefinitions(List<MineralSD> minerals,
+            List<ProcessedMaterialSD> processedMaterials,
+            List<ICargoable> otherCargo)
+        {
+            LoadMineralDefinitions(minerals);
+            LoadMaterialsDefinitions(processedMaterials);
+            LoadOtherDefinitions(otherCargo);
+        }
+
+        public void LoadMineralDefinitions(List<MineralSD> minerals)
+        {
+            if (minerals != null)
+            {
+                foreach (var entry in minerals)
+                {
+                    _definitions[entry.ID] = entry;
+                    _minerals[entry.ID] = entry;
+                }
+            }
+        }
+
+        public void LoadMaterialsDefinitions(List<ProcessedMaterialSD> materials)
+        {
+            if (materials != null)
+            {
+                foreach (var entry in materials)
+                {
+                    _definitions[entry.ID] = entry;
+                    _processedMaterials[entry.ID] = entry;
+                }
+            }
+        }
+
+        public void LoadOtherDefinitions(List<ICargoable> otherCargo)
+        {
+            if (otherCargo != null)
+            {
+                foreach (var entry in otherCargo)
+                {
+                    _definitions[entry.ID] = entry;
+                }
+            }
+        }
+
+        public object GetAny(Guid id)
+        {
+            if (_minerals.ContainsKey(id))
+                return _minerals[id];
+
+            if (_processedMaterials.ContainsKey(id))
+                return _processedMaterials[id];
+
+            if (_definitions.ContainsKey(id))
+                return _definitions[id];
+
+            return null;
+        }
+
+        public Dictionary<Guid, ICargoable> GetAll()
+        {
+            return _definitions;
+        }
+
+
+        public bool IsOther(Guid id)
+        {
+            return _definitions.ContainsKey(id);
+        }
+
+        public ICargoable GetOther(string nameOfCargo)
+        {
+            if (_definitions.Values.Any(tg => tg.Name == nameOfCargo))
+            {
+                return _definitions.Values.Single(tg => tg.Name == nameOfCargo);
+            }
+
+            throw new Exception("Cargo item with the name " + nameOfCargo + " not found in TradeGoodLibrary. Was the trade good properly loaded?");
+        }
+
+        public ICargoable GetOther(Guid guidOfCargo)
+        {
+            return _definitions[guidOfCargo];
+        }
+
+
+        public bool IsMineral(Guid id)
+        {
+            return _minerals.ContainsKey(id);
+        }
+
+        public MineralSD GetMineral(string name)
+        {
+            var result = GetOther(name);
+            return _minerals[result.ID];
+        }
+
+        public MineralSD GetMineral(Guid guid)
+        {
+            var result = GetOther(guid);
+            return _minerals[result.ID];
+        }
+
+        public Dictionary<Guid, MineralSD> GetMinerals()
+        {
+            return _minerals;
+        }
+
+        public List<MineralSD> GetMineralsList()
+        {
+            return _minerals.Values.ToList();
+        }
+
+
+        public bool IsMaterial(Guid id)
+        {
+            return _processedMaterials.ContainsKey(id);
+        }
+
+        public ProcessedMaterialSD GetMaterial(string name)
+        {
+            var result = GetOther(name);
+            return _processedMaterials[result.ID];
+        }
+
+        public ProcessedMaterialSD GetMaterial(Guid guid)
+        {
+            var result = GetOther(guid);
+            return _processedMaterials[result.ID];
+        }
+
+        public Dictionary<Guid, ProcessedMaterialSD> GetMaterials()
+        {
+            return _processedMaterials;
+        }
+
+        public List<ProcessedMaterialSD> GetMaterialsList()
+        {
+            return _processedMaterials.Values.ToList();
+        }
+    }
+}

--- a/Pulsar4X/Pulsar4X.ECSLib/ComponentFeatureSets/CargoStorage/CargoDefinitionsLibrary.cs
+++ b/Pulsar4X/Pulsar4X.ECSLib/ComponentFeatureSets/CargoStorage/CargoDefinitionsLibrary.cs
@@ -127,7 +127,7 @@ namespace Pulsar4X.ECSLib.ComponentFeatureSets.CargoStorage
 
         public bool IsOther(Guid id)
         {
-            return _definitions.ContainsKey(id);
+            return _definitions.ContainsKey(id) && (IsMineral(id) == false) && (IsMaterial(id) == false);
         }
 
         public ICargoable GetOther(string nameOfCargo)

--- a/Pulsar4X/Pulsar4X.ECSLib/ComponentFeatureSets/CargoStorage/CargoStorageDB.cs
+++ b/Pulsar4X/Pulsar4X.ECSLib/ComponentFeatureSets/CargoStorage/CargoStorageDB.cs
@@ -18,8 +18,6 @@ namespace Pulsar4X.ECSLib
         /// </summary>
         [JsonProperty]
         public Dictionary<Guid, CargoTypeStore> StoredCargoTypes { get; private set; } = new Dictionary<Guid, CargoTypeStore>();
-        public Dictionary<Guid, CargoTypeStore> OutgoingCargoTypes { get; private set; } = new Dictionary<Guid, CargoTypeStore>();
-        public Dictionary<Guid, CargoTypeStore> IncomingCargoTypes { get; private set; } = new Dictionary<Guid, CargoTypeStore>();
 
         /// <summary>
         /// Gets or sets the transfer rate in kg hr.
@@ -59,13 +57,6 @@ namespace Pulsar4X.ECSLib
     /// </summary>
     public class CargoTypeStore
     {
-        //[JsonProperty]
-        /// <summary>
-        /// This is the CargoTypeSD.ID/ICargoable.CargoTypeID
-        /// </summary>
-        /// <value>The CargoType GUID.</value>
-        //internal Guid TypeGuid { get; set; } //irelevent since this is stored in a dictionary with this as a key. 
-
         /// <summary>
         /// The Maximum that this entity can store of this type.
         /// </summary>

--- a/Pulsar4X/Pulsar4X.ECSLib/ComponentFeatureSets/CargoStorage/StorageSpaceProcessor.cs
+++ b/Pulsar4X/Pulsar4X.ECSLib/ComponentFeatureSets/CargoStorage/StorageSpaceProcessor.cs
@@ -247,6 +247,16 @@ namespace Pulsar4X.ECSLib
                 }
             }
         }
+
+        public static long GetAvailableSpaceInItemCount(CargoStorageDB storeDB, Guid itemGuid, ICargoDefinitionsLibrary library)
+        {
+            var cargoDefinition = library.GetOther(itemGuid);
+            if (cargoDefinition.Mass == 0)
+                return long.MaxValue;
+
+            return storeDB.StoredCargoTypes[cargoDefinition.CargoTypeID].FreeCapacityKg / cargoDefinition.Mass;
+        }
+
     }
 
 }

--- a/Pulsar4X/Pulsar4X.ECSLib/ComponentFeatureSets/CargoStorage/StorageSpaceProcessor.cs
+++ b/Pulsar4X/Pulsar4X.ECSLib/ComponentFeatureSets/CargoStorage/StorageSpaceProcessor.cs
@@ -248,13 +248,15 @@ namespace Pulsar4X.ECSLib
             }
         }
 
-        public static long GetAvailableSpaceInItemCount(CargoStorageDB storeDB, Guid itemGuid, ICargoDefinitionsLibrary library)
+        public static CargoCapacityCheckResult GetAvailableSpace(CargoStorageDB storeDB, Guid itemGuid, ICargoDefinitionsLibrary library)
         {
             var cargoDefinition = library.GetOther(itemGuid);
             if (cargoDefinition.Mass == 0)
-                return long.MaxValue;
+                return new CargoCapacityCheckResult(itemGuid, long.MaxValue, long.MaxValue);
 
-            return storeDB.StoredCargoTypes[cargoDefinition.CargoTypeID].FreeCapacityKg / cargoDefinition.Mass;
+            return new CargoCapacityCheckResult(itemGuid, 
+                storeDB.StoredCargoTypes[cargoDefinition.CargoTypeID].FreeCapacityKg / cargoDefinition.Mass,
+                storeDB.StoredCargoTypes[cargoDefinition.CargoTypeID].FreeCapacityKg);
         }
 
     }

--- a/Pulsar4X/Pulsar4X.ECSLib/ComponentFeatureSets/CargoStorage/StorageSpaceProcessor.cs
+++ b/Pulsar4X/Pulsar4X.ECSLib/ComponentFeatureSets/CargoStorage/StorageSpaceProcessor.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Pulsar4X.ECSLib.ComponentFeatureSets.CargoStorage;
+using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
@@ -44,6 +45,7 @@ namespace Pulsar4X.ECSLib
         {
             return storeDB.StoredCargoTypes[storeTypeGuid].ItemsAndAmounts[itemGuid];
         }
+
         public static long GetAmount(CargoStorageDB storeDB, ICargoable item)
         {
             return storeDB.StoredCargoTypes[item.CargoTypeID].ItemsAndAmounts[item.ID];

--- a/Pulsar4X/Pulsar4X.ECSLib/ComponentFeatureSets/Components/GenericComponent.cs
+++ b/Pulsar4X/Pulsar4X.ECSLib/ComponentFeatureSets/Components/GenericComponent.cs
@@ -131,7 +131,7 @@ namespace Pulsar4X.ECSLib
             foreach (var kvp in componentDesign.MineralCostValues)
             {
 
-                if (staticData.ProcessedMaterials.ContainsKey(kvp.Key))
+                if (staticData.CargoGoods.IsMaterial(kvp.Key))
                 {
                     materalCosts.Add(kvp.Key, kvp.Value);
                 }
@@ -139,7 +139,7 @@ namespace Pulsar4X.ECSLib
                 {
                     componentCosts.Add(kvp.Key, kvp.Value);
                 }
-                else if (staticData.Minerals.ContainsKey(kvp.Key))
+                else if (staticData.CargoGoods.IsMineral(kvp.Key))
                 {
                     mineralCosts.Add(kvp.Key, kvp.Value);
                 }

--- a/Pulsar4X/Pulsar4X.ECSLib/ComponentFeatureSets/MineResources/MineProcessor.cs
+++ b/Pulsar4X/Pulsar4X.ECSLib/ComponentFeatureSets/MineResources/MineProcessor.cs
@@ -17,7 +17,7 @@ namespace Pulsar4X.ECSLib
 
         public void Init(Game game)
         {
-            _minerals = game.StaticData.Minerals;
+            _minerals = game.StaticData.CargoGoods.GetMinerals();
         }
         
         public void ProcessEntity(Entity entity, int deltaSeconds)

--- a/Pulsar4X/Pulsar4X.ECSLib/ComponentFeatureSets/RefineResources/RefineOrders.cs
+++ b/Pulsar4X/Pulsar4X.ECSLib/ComponentFeatureSets/RefineResources/RefineOrders.cs
@@ -49,9 +49,9 @@ namespace Pulsar4X.ECSLib
             _staticData = game.StaticData;
             if (CommandHelpers.IsCommandValid(game.GlobalManager, RequestingFactionGuid, EntityCommandingGuid, out _factionEntity, out _entityCommanding))
             {
-                if (_staticData.ProcessedMaterials.ContainsKey(MaterialGuid))
+                if (_staticData.CargoGoods.IsMaterial(MaterialGuid))
                 {
-                    int pointCost = _staticData.ProcessedMaterials[MaterialGuid].RefineryPointCost;
+                    int pointCost = _staticData.CargoGoods.GetMaterial(MaterialGuid).RefineryPointCost;
                     _job = new RefineingJob(MaterialGuid, NumberOrderd, pointCost, RepeatJob);
                     return true;
                 }

--- a/Pulsar4X/Pulsar4X.ECSLib/ComponentFeatureSets/RefineResources/RefiningProcessor.cs
+++ b/Pulsar4X/Pulsar4X.ECSLib/ComponentFeatureSets/RefineResources/RefiningProcessor.cs
@@ -23,7 +23,7 @@ namespace Pulsar4X.ECSLib
 
         public void Init(Game game)
         {
-            ProcessedMaterials = game.StaticData.ProcessedMaterials;
+            ProcessedMaterials = game.StaticData.CargoGoods.GetMaterials();
         }
 
         public void ProcessEntity(Entity entity, int deltaSeconds)
@@ -67,7 +67,7 @@ namespace Pulsar4X.ECSLib
                     Dictionary<ICargoable, int> cargoablecosts = new Dictionary<ICargoable, int>();
                     foreach (var kvp in material.RawMineralCosts)
                     {
-                        ICargoable cargoItem = staticData.Minerals[kvp.Key];
+                        ICargoable cargoItem = staticData.CargoGoods.GetMineral(kvp.Key);
                         cargoablecosts.Add(cargoItem, kvp.Value);
                     }
                     
@@ -209,7 +209,7 @@ namespace Pulsar4X.ECSLib
             lock (refiningDB.JobBatchList) //prevent threaded race conditions
             {
                 //check if the job materialguid is valid, then add it if so.
-                if (staticData.ProcessedMaterials.ContainsKey(job.ItemGuid))
+                if (staticData.CargoGoods.IsMaterial(job.ItemGuid))
                 {
                     refiningDB.JobBatchList.Add(job);
                 }

--- a/Pulsar4X/Pulsar4X.ECSLib/ComponentFeatureSets/RefineResources/RefiningVM.cs
+++ b/Pulsar4X/Pulsar4X.ECSLib/ComponentFeatureSets/RefineResources/RefiningVM.cs
@@ -63,7 +63,7 @@ namespace Pulsar4X.ECSLib
             _orderHandler = game.OrderHandler;
             _factionGuid = refiningDB.OwningEntity.FactionOwner;
             _cmdRef = cmdRef;
-            foreach (var kvp in _staticData.ProcessedMaterials)
+            foreach (var kvp in _staticData.CargoGoods.GetMaterials())
             {
                 ItemDictionary.Add(kvp.Key, kvp.Value.Name);
             }
@@ -143,7 +143,7 @@ namespace Pulsar4X.ECSLib
             _parent = parentVM;
             _staticData = staticData;
             JobItem = job;
-            Item = _staticData.ProcessedMaterials[JobItem.ItemGuid].Name;
+            Item = _staticData.CargoGoods.GetMaterial(JobItem.ItemGuid).Name;
             _cmdRef = cmdRef;
         }
 

--- a/Pulsar4X/Pulsar4X.ECSLib/Factories/SystemGen/SystemBodyFactory.cs
+++ b/Pulsar4X/Pulsar4X.ECSLib/Factories/SystemGen/SystemBodyFactory.cs
@@ -843,7 +843,7 @@ namespace Pulsar4X.ECSLib
             }
 
             // this body has at least some minerals, lets generate them:
-            foreach (var min in staticData.Minerals.Values)
+            foreach (var min in staticData.CargoGoods.GetMineralsList())
             {
                 // create a MineralDepositInfo
                 MineralDepositInfo mdi = new MineralDepositInfo();
@@ -875,7 +875,7 @@ namespace Pulsar4X.ECSLib
             var bodyInfo = body.GetDataBlob<SystemBodyInfoDB>();
             bodyInfo.Minerals.Clear();  // because this function can be called on existing bodies we need to clear any existing minerals.
 
-            foreach (var min in staticData.Minerals.Values)
+            foreach (var min in staticData.CargoGoods.GetMineralsList())
             {
                 // create a MineralDepositInfo
                 MineralDepositInfo mdi = new MineralDepositInfo

--- a/Pulsar4X/Pulsar4X.ECSLib/Helpers/NameLookup.cs
+++ b/Pulsar4X/Pulsar4X.ECSLib/Helpers/NameLookup.cs
@@ -48,26 +48,12 @@ namespace Pulsar4X.ECSLib
 
         internal static MineralSD GetMineralSD(Game game, string name)
         {
-            foreach (var kvp in game.StaticData.Minerals)
-            {
-                if (name == kvp.Value.Name)
-                {
-                    return kvp.Value;
-                }
-            }
-            throw new Exception(name + " not found");
+            return game.StaticData.CargoGoods.GetMineral(name);
         }
         
         internal static ProcessedMaterialSD GetMaterialSD(Game game, string name)
         {
-            foreach (var kvp in game.StaticData.ProcessedMaterials)
-            {
-                if (name == kvp.Value.Name)
-                {
-                    return kvp.Value;
-                }
-            }
-            throw new Exception(name + " not found");
+            return game.StaticData.CargoGoods.GetMaterial(name);
         }
 
         internal static ComponentTemplateSD GetTemplateSD(Game game, string name)

--- a/Pulsar4X/Pulsar4X.ECSLib/OldViewModels/ColonyScreenVM.cs
+++ b/Pulsar4X/Pulsar4X.ECSLib/OldViewModels/ColonyScreenVM.cs
@@ -133,7 +133,7 @@ namespace Pulsar4X.ECSLib
             _mineralDeposits.Clear();
             foreach (var kvp in minerals)
             {
-                MineralSD mineral = _staticData.Minerals[kvp.Key];
+                MineralSD mineral = _staticData.CargoGoods.GetMineral(kvp.Key);
                 if (!_mineralDeposits.ContainsKey(kvp.Key))
                     _mineralDeposits.Add(kvp.Key, new PlanetMineralInfoVM(mineral.Name, kvp.Value));
             }

--- a/Pulsar4X/Pulsar4X.ECSLib/OldViewModels/ComponentDesignVM.cs
+++ b/Pulsar4X/Pulsar4X.ECSLib/OldViewModels/ComponentDesignVM.cs
@@ -76,7 +76,7 @@ namespace Pulsar4X.ECSLib
                     text += "ResearchCost: " + Design.ResearchCostValue + Environment.NewLine;
                     foreach (var kvp in Design.MineralCostValues)
                     {
-                        string mineralName = _staticData.Minerals[kvp.Key].Name;
+                        string mineralName = _staticData.CargoGoods.GetMineral(kvp.Key).Name;
                         text += mineralName + ": " + kvp.Value + Environment.NewLine;
                     }
                     text += "Credit Cost: " + Design.CreditCostValue + Environment.NewLine;

--- a/Pulsar4X/Pulsar4X.ECSLib/OldViewModels/ComponentTemplateDesigner/MineralFormulaVM.cs
+++ b/Pulsar4X/Pulsar4X.ECSLib/OldViewModels/ComponentTemplateDesigner/MineralFormulaVM.cs
@@ -49,7 +49,7 @@ namespace Pulsar4X.ECSLib
         {
             _dataStore = staticDataStore;
             Minerals = new DictionaryVM<Guid, string>(DisplayMode.Value);
-            foreach (var item in staticDataStore.Minerals.Values)
+            foreach (var item in staticDataStore.CargoGoods.GetMineralsList())
             {
                 Minerals.Add(item.ID, item.Name);
             }

--- a/Pulsar4X/Pulsar4X.ECSLib/OldViewModels/JobVM.cs
+++ b/Pulsar4X/Pulsar4X.ECSLib/OldViewModels/JobVM.cs
@@ -21,7 +21,7 @@ namespace Pulsar4X.ECSLib
             get
             {
                 if (_job is RefineingJob)
-                    return _staticData.ProcessedMaterials[_job.ItemGuid].Name;
+                    return _staticData.CargoGoods.GetMaterial(_job.ItemGuid).Name;
                 else if (_job is ConstructionJob)
                 {
                     Entity faction;
@@ -56,7 +56,7 @@ namespace Pulsar4X.ECSLib
             _parentJobAbility = parentJobAbilityVM;
 
             if (_job is RefineingJob)
-                _jobTotalPoints = _staticData.ProcessedMaterials[_job.ItemGuid].RefineryPointCost;
+                _jobTotalPoints = _staticData.CargoGoods.GetMaterial(_job.ItemGuid).RefineryPointCost;
             else if (_job is ConstructionJob)
                 _jobTotalPoints = _colonyEntity.GetDataBlob<ObjectOwnershipDB>().Parent.GetDataBlob<FactionInfoDB>().ComponentDesigns[_job.ItemGuid].GetDataBlob<ComponentInfoDB>().BuildPointCost;
 

--- a/Pulsar4X/Pulsar4X.ECSLib/OldViewModels/RefineryAbilityVM.cs
+++ b/Pulsar4X/Pulsar4X.ECSLib/OldViewModels/RefineryAbilityVM.cs
@@ -122,9 +122,9 @@ namespace Pulsar4X.ECSLib
         public RefineryAbilityVM(StaticDataStore staticData, Entity colonyEntity) : base(staticData, colonyEntity)
         {
             ItemDictionary = new DictionaryVM<Guid, string>(DisplayMode.Value);
-            foreach (var kvp in _staticData_.ProcessedMaterials)
+            foreach (var kvp in _staticData_.CargoGoods.GetMaterialsList())
             {
-                ItemDictionary.Add(kvp.Key, kvp.Value.Name);
+                ItemDictionary.Add(kvp.ID, kvp.Name);
             }
             //NewJobSelectedItem = ItemDictionary[ItemDictionary.ElementAt(0).Key];
             NewJobSelectedIndex = 0;
@@ -134,7 +134,7 @@ namespace Pulsar4X.ECSLib
 
         public override void OnNewBatchJob()
         {
-            RefineingJob newjob = new RefineingJob(NewJobSelectedItem, NewJobBatchCount, _staticData_.ProcessedMaterials[NewJobSelectedItem].RefineryPointCost, NewJobRepeat);
+            RefineingJob newjob = new RefineingJob(NewJobSelectedItem, NewJobBatchCount, _staticData_.CargoGoods.GetMaterial(NewJobSelectedItem).RefineryPointCost, NewJobRepeat);
             RefiningProcessor.AddJob(_staticData_, _colonyEntity_, newjob);
             Refresh();
         }

--- a/Pulsar4X/Pulsar4X.Tests/CargoSpaceTests.cs
+++ b/Pulsar4X/Pulsar4X.Tests/CargoSpaceTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using NUnit.Framework;
 using Pulsar4X.ECSLib;
 using System.Diagnostics;
+using Pulsar4X.ECSLib.ComponentFeatureSets.CargoStorage;
 
 namespace Pulsar4X.Tests
 {
@@ -119,6 +120,28 @@ namespace Pulsar4X.Tests
             };
             var hasCookies = StorageSpaceProcessor.HasRequiredItems(cookiePile, cookieCheck);
             Assert.IsTrue(hasCookies);
+        }
+
+        [Test]
+        public void StorageSpaceProcessor_When_AskedToCheckAvailableStorageSpace_Should_ReturnCorrectAnswerForTheRequestedCargoItem()
+        {
+            var cookies = SetupCookieTradeGood();
+            var library = new CargoDefinitionsLibrary();
+            library.LoadOtherDefinitions(new List<ICargoable>() { cookies });
+
+            var cookiePile = new CargoStorageDB();
+            cookiePile.StoredCargoTypes.Add(cookies.CargoTypeID, new CargoTypeStore() { MaxCapacityKg = 35007, FreeCapacityKg = 32154 });
+            cookiePile.StoredCargoTypes.Add(Guid.NewGuid(), new CargoTypeStore() { MaxCapacityKg = 99998, FreeCapacityKg = 99997 });
+            cookiePile.StoredCargoTypes.Add(Guid.NewGuid(), new CargoTypeStore() { MaxCapacityKg = 99996, FreeCapacityKg = 99995 });
+
+            var canStoreThisManyItems = StorageSpaceProcessor.GetAvailableSpaceInItemCount(cookiePile, cookies.ID, library);
+            Assert.AreEqual(32154, canStoreThisManyItems);
+
+            StorageSpaceProcessor.AddCargo(cookiePile, cookies, 2154);
+
+            canStoreThisManyItems = StorageSpaceProcessor.GetAvailableSpaceInItemCount(cookiePile, cookies.ID, library);
+            Assert.AreEqual(30000, canStoreThisManyItems);
+
         }
 
         private ProcessedMaterialSD SetupCookieTradeGood()

--- a/Pulsar4X/Pulsar4X.Tests/CargoSpaceTests.cs
+++ b/Pulsar4X/Pulsar4X.Tests/CargoSpaceTests.cs
@@ -125,23 +125,24 @@ namespace Pulsar4X.Tests
         [Test]
         public void StorageSpaceProcessor_When_AskedToCheckAvailableStorageSpace_Should_ReturnCorrectAnswerForTheRequestedCargoItem()
         {
-            var cookies = SetupCookieTradeGood();
+            var rocks = SetupRockTradeGood();
             var library = new CargoDefinitionsLibrary();
-            library.LoadOtherDefinitions(new List<ICargoable>() { cookies });
+            library.LoadOtherDefinitions(new List<ICargoable>() { rocks });
 
-            var cookiePile = new CargoStorageDB();
-            cookiePile.StoredCargoTypes.Add(cookies.CargoTypeID, new CargoTypeStore() { MaxCapacityKg = 35007, FreeCapacityKg = 32154 });
-            cookiePile.StoredCargoTypes.Add(Guid.NewGuid(), new CargoTypeStore() { MaxCapacityKg = 99998, FreeCapacityKg = 99997 });
-            cookiePile.StoredCargoTypes.Add(Guid.NewGuid(), new CargoTypeStore() { MaxCapacityKg = 99996, FreeCapacityKg = 99995 });
+            var rockPile = new CargoStorageDB();
+            rockPile.StoredCargoTypes.Add(rocks.CargoTypeID, new CargoTypeStore() { MaxCapacityKg = 35007, FreeCapacityKg = 32154 });
+            rockPile.StoredCargoTypes.Add(Guid.NewGuid(), new CargoTypeStore() { MaxCapacityKg = 99998, FreeCapacityKg = 99997 });
+            rockPile.StoredCargoTypes.Add(Guid.NewGuid(), new CargoTypeStore() { MaxCapacityKg = 99996, FreeCapacityKg = 99995 });
 
-            var canStoreThisManyItems = StorageSpaceProcessor.GetAvailableSpaceInItemCount(cookiePile, cookies.ID, library);
-            Assert.AreEqual(32154, canStoreThisManyItems);
+            var canStoreThisManyItems = StorageSpaceProcessor.GetAvailableSpace(rockPile, rocks.ID, library);
+            Assert.AreEqual(3215, canStoreThisManyItems.FreeCapacityItem);
+            Assert.AreEqual(32154, canStoreThisManyItems.FreeCapacityKg);
 
-            StorageSpaceProcessor.AddCargo(cookiePile, cookies, 2154);
+            StorageSpaceProcessor.AddCargo(rockPile, rocks, 215);
 
-            canStoreThisManyItems = StorageSpaceProcessor.GetAvailableSpaceInItemCount(cookiePile, cookies.ID, library);
-            Assert.AreEqual(30000, canStoreThisManyItems);
-
+            canStoreThisManyItems = StorageSpaceProcessor.GetAvailableSpace(rockPile, rocks.ID, library);
+            Assert.AreEqual(3000, canStoreThisManyItems.FreeCapacityItem);
+            Assert.AreEqual(30004, canStoreThisManyItems.FreeCapacityKg);
         }
 
         private ProcessedMaterialSD SetupCookieTradeGood()
@@ -156,6 +157,20 @@ namespace Pulsar4X.Tests
             };
 
             return cookies;
+        }
+
+        private ProcessedMaterialSD SetupRockTradeGood()
+        {
+            var rock = new ProcessedMaterialSD
+            {
+                Name = "Rock",
+                Description = "A pile of heavy rocks. Very useful. Trust me.",
+                ID = Guid.NewGuid(),
+                CargoTypeID = Guid.NewGuid(),
+                Mass = 10
+            };
+
+            return rock;
         }
     }
 }

--- a/Pulsar4X/Pulsar4X.Tests/CargoSpaceTests.cs
+++ b/Pulsar4X/Pulsar4X.Tests/CargoSpaceTests.cs
@@ -34,6 +34,169 @@ namespace Pulsar4X.Tests
         }
 
         [Test]
+        public void CargoDefinitionsLibrary_When_AskedIfSomethingIsAMineral_Should_CorrectlyRespond()
+        {
+            var minerals = new List<MineralSD>();
+            var mineralCargoTypeId = Guid.NewGuid();
+
+            var otherJunk = new List<ICargoable>();
+            var otherCargoTypeId = Guid.NewGuid();
+
+            var theDice = new Random();
+
+            var diceRollMinerals = theDice.Next(15, 20);
+            for (var i = 0; i < diceRollMinerals; i++)
+            {
+                var randomMineral = new MineralSD()
+                {
+                    ID = Guid.NewGuid(),
+                    CargoTypeID = mineralCargoTypeId,
+                    Mass = 1000,
+                    Name = "RandomMineral_" + i.ToString(),
+                    Description = "A random mineral."
+                };
+                minerals.Add(randomMineral);
+            }
+
+            var diceRoll = theDice.Next(15, 20);
+            for (var i = 0; i < diceRoll; i++)
+            {
+                var randomCargoThing = new JustSomeCargoThing()
+                {
+                    ID = Guid.NewGuid(),
+                    CargoTypeID = otherCargoTypeId,
+                    Mass = 1000,
+                    Name = "AThing_" + i.ToString()
+                };
+                otherJunk.Add(randomCargoThing);
+            }
+            
+            var library = new CargoDefinitionsLibrary();
+            library.LoadMineralDefinitions(minerals);
+            library.LoadOtherDefinitions(otherJunk);
+
+            for (var i = 0; i < diceRollMinerals; i++)
+            {
+                Assert.IsTrue(library.IsMineral(minerals[i].ID));
+            }
+            for (var i = 0; i < diceRoll; i++)
+            {
+                Assert.IsFalse(library.IsMineral(otherJunk[i].ID));
+            }
+        }
+
+        [Test]
+        public void CargoDefinitionsLibrary_When_AskedIfSomethingIsAMaterial_Should_CorrectlyRespond()
+        {
+            var materials = new List<ProcessedMaterialSD>();
+            var materialCargoTypeId = Guid.NewGuid();
+
+            var otherJunk = new List<ICargoable>();
+            var otherCargoTypeId = Guid.NewGuid();
+
+            var theDice = new Random();
+
+            var diceRollMaterials = theDice.Next(15, 20);
+            for (var i = 0; i < diceRollMaterials; i++)
+            {
+                var randomMaterial = new ProcessedMaterialSD()
+                {
+                    ID = Guid.NewGuid(),
+                    CargoTypeID = materialCargoTypeId,
+                    Mass = 1000,
+                    Name = "RandomMaterial_" + i.ToString(),
+                    Description = "A random material."
+                };
+                materials.Add(randomMaterial);
+            }
+
+            var diceRoll = theDice.Next(15, 20);
+            for (var i = 0; i < diceRoll; i++)
+            {
+                var randomCargoThing = new JustSomeCargoThing()
+                {
+                    ID = Guid.NewGuid(),
+                    CargoTypeID = otherCargoTypeId,
+                    Mass = 1000,
+                    Name = "AThing_" + i.ToString()
+                };
+                otherJunk.Add(randomCargoThing);
+            }
+
+            var library = new CargoDefinitionsLibrary();
+            library.LoadMaterialsDefinitions(materials);
+            library.LoadOtherDefinitions(otherJunk);
+
+            for (var i = 0; i < diceRollMaterials; i++)
+            {
+                Assert.IsTrue(library.IsMaterial(materials[i].ID));
+            }
+            for (var i = 0; i < diceRoll; i++)
+            {
+                Assert.IsFalse(library.IsMaterial(otherJunk[i].ID));
+            }
+        }
+
+        [Test]
+        public void CargoDefinitionsLibrary_When_AskedIfSomethingIsOtherCargo_Should_CorrectlyRespond()
+        {
+            var materials = new List<ProcessedMaterialSD>();
+            var materialCargoTypeId = Guid.NewGuid();
+
+            var otherJunk = new List<ICargoable>();
+            var otherCargoTypeId = Guid.NewGuid();
+
+            var theDice = new Random();
+
+            var diceRollMaterials = theDice.Next(15, 20);
+            for (var i = 0; i < diceRollMaterials; i++)
+            {
+                var randomMaterial = new ProcessedMaterialSD()
+                {
+                    ID = Guid.NewGuid(),
+                    CargoTypeID = materialCargoTypeId,
+                    Mass = 1000,
+                    Name = "RandomMaterial_" + i.ToString(),
+                    Description = "A random material."
+                };
+                materials.Add(randomMaterial);
+            }
+
+            var diceRoll = theDice.Next(15, 20);
+            for (var i = 0; i < diceRoll; i++)
+            {
+                var randomCargoThing = new JustSomeCargoThing()
+                {
+                    ID = Guid.NewGuid(),
+                    CargoTypeID = otherCargoTypeId,
+                    Mass = 1000,
+                    Name = "AThing_" + i.ToString()
+                };
+                otherJunk.Add(randomCargoThing);
+            }
+
+            var library = new CargoDefinitionsLibrary();
+            library.LoadMaterialsDefinitions(materials);
+            library.LoadOtherDefinitions(otherJunk);
+
+            for (var i = 0; i < diceRollMaterials; i++)
+            {
+                Assert.IsFalse(library.IsOther(materials[i].ID));
+            }
+            for (var i = 0; i < diceRoll; i++)
+            {
+                Assert.IsTrue(library.IsOther(otherJunk[i].ID));
+            }
+        }
+
+        [Test]
+        public void CargoDefinitionsLibrary_When_GEttingADefinitionFromTheLibraryThatDoesnotExist_Should_ReturnNull()
+        {
+            var library = new CargoDefinitionsLibrary();
+            Assert.IsNull(library.GetAny(Guid.NewGuid()));
+        }
+
+        [Test]
         public void StorageSpaceProcessor_When_AskedToCheckIfItHasACargoTypeThatItDoesnotHave_Should_ReturnFalse()
         {
             var cookies = SetupCookieTradeGood();
@@ -172,5 +335,16 @@ namespace Pulsar4X.Tests
 
             return rock;
         }
+    }
+
+    public class JustSomeCargoThing : ICargoable
+    {
+        public Guid ID { get; set; }
+
+        public string Name { get; set; }
+
+        public Guid CargoTypeID { get; set; }
+
+        public int Mass { get; set; }
     }
 }

--- a/Pulsar4X/Pulsar4X.Tests/Pulsar4X.Tests.csproj
+++ b/Pulsar4X/Pulsar4X.Tests/Pulsar4X.Tests.csproj
@@ -63,6 +63,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.4.1" />
     <PackageReference Include="ncalc" Version="1.3.8" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
     <Compile Remove="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Pulsar4X/Pulsar4X.Tests/StaticDataTests.cs
+++ b/Pulsar4X/Pulsar4X.Tests/StaticDataTests.cs
@@ -322,14 +322,14 @@ namespace Pulsar4X.Tests
             var staticDataStore = game.StaticData;
 
             // store counts for later:
-            int mineralsNum = staticDataStore.Minerals.Count;
+            int mineralsNum = staticDataStore.CargoGoods.GetMineralsList().Count;
             int techNum = staticDataStore.Techs.Count;
-            int constructableObjectsNum = staticDataStore.ProcessedMaterials.Count;
+            int constructableObjectsNum = staticDataStore.CargoGoods.GetMaterialsList().Count;
 
             // check that data was loaded:
-            Assert.IsNotEmpty(staticDataStore.Minerals);
+            Assert.IsNotEmpty(staticDataStore.CargoGoods.GetMineralsList());
             Assert.IsNotEmpty(staticDataStore.AtmosphericGases);
-            Assert.IsNotEmpty(staticDataStore.ProcessedMaterials);
+            Assert.IsNotEmpty(staticDataStore.CargoGoods.GetMaterialsList());
             Assert.IsNotEmpty(staticDataStore.CargoTypes);
             Assert.IsNotEmpty(staticDataStore.Techs);
 
@@ -337,9 +337,9 @@ namespace Pulsar4X.Tests
             StaticDataManager.LoadData("Pulsar4x", game);
 
             // now check that overwriting occured and that there were no duplicates:
-            Assert.AreEqual(mineralsNum, staticDataStore.Minerals.Count);
+            Assert.AreEqual(mineralsNum, staticDataStore.CargoGoods.GetMineralsList().Count);
             Assert.AreEqual(techNum, staticDataStore.Techs.Count);
-            Assert.AreEqual(constructableObjectsNum, staticDataStore.ProcessedMaterials.Count);
+            Assert.AreEqual(constructableObjectsNum, staticDataStore.CargoGoods.GetMaterialsList().Count);
 
             // now lets test some malformed data folders.
             StaticDataLoadException ex = Assert.Throws<StaticDataLoadException>(
@@ -360,17 +360,17 @@ namespace Pulsar4X.Tests
             var staticDataStore = game.StaticData;
 
             // store counts for later:
-            int mineralsNum = staticDataStore.Minerals.Count;
+            int mineralsNum = staticDataStore.CargoGoods.GetMineralsList().Count;
             Guid someGuid = new Guid("08f15d35-ea1d-442f-a2e3-bde04c5c22e9");
-            string someName = staticDataStore.Minerals[someGuid].Name;
+            string someName = staticDataStore.CargoGoods.GetMineral(someGuid).Name;
             
             StaticDataManager.LoadData("Other", game);
             staticDataStore = game.StaticData;
             
             // now check that overwriting occured and that there were no duplicates:
-            Assert.AreEqual(mineralsNum, staticDataStore.Minerals.Count);
+            Assert.AreEqual(mineralsNum, staticDataStore.CargoGoods.GetMineralsList().Count);
             //check the name has been overwritten
-            Assert.AreNotEqual(someName, staticDataStore.Minerals[someGuid].Name);
+            Assert.AreNotEqual(someName, staticDataStore.CargoGoods.GetMineral(someGuid).Name);
         }
 
         [Test]
@@ -392,7 +392,7 @@ namespace Pulsar4X.Tests
             Assert.IsNull(testObj);
 
             // now lets test for values that are in the store:
-            Guid testID = staticDataStore.Minerals.FirstOrDefault().Key;
+            Guid testID = staticDataStore.CargoGoods.GetMinerals().FirstOrDefault().Key;
             testObj = staticDataStore.FindDataObjectUsingID(testID);
             Assert.IsNotNull(testObj);
             Assert.AreEqual(testID, ((MineralSD)testObj).ID);


### PR DESCRIPTION
This is mostly a refactor branch.
Functionally nothing has changed.

I moved some of the Static Data (specifically minerals and materials) into a new class library that keeps track of those definitions.
The idea is that the library is easier to encapsulate / isolate for testing purposes. (Or instantiate as part of other tests.)

Secondly, the idea is that in a future refactors the cargo only needs to keep track of the Guid of the stored cargo. To get more info (such as type or mass) the library can be queried using the Guid.

A new added function in StorageSpaceProcessor for checking free space makes use of this approach.

lastly, the library also has some convenience functions, such as fetching a definition by name instead of Guid. Or getting the definitions as a list.

I've also removed some lines of unused (not references) code.
