### PR TITLE
Fix text on system window overlapping other windows.

### DIFF
--- a/Pulsar4X/Pulsar4X.ImGuiNetUI/MapRendering/Icons/NameIcon.cs
+++ b/Pulsar4X/Pulsar4X.ImGuiNetUI/MapRendering/Icons/NameIcon.cs
@@ -35,7 +35,7 @@ namespace Pulsar4X.SDL2UI
     public class NameIcon : Icon, IComparable<NameIcon>, IRectangle
     {
 
-        protected ImGuiWindowFlags _flags = ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoSavedSettings;
+        protected ImGuiWindowFlags _flags = ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoSavedSettings | ImGuiWindowFlags.NoBringToFrontOnFocus;
         internal bool IsActive = true;
         GlobalUIState _state;
         NameDB _nameDB;


### PR DESCRIPTION
This prevents NameIcons' text from being in front of other windows. E.g. the current entity selected window.