### PR TITLE
Use Location property in GetWorkingDirectory() 

### DIFF
--- a/Pulsar4X/Pulsar4X.ECSLib/SerializationManager.cs
+++ b/Pulsar4X/Pulsar4X.ECSLib/SerializationManager.cs
@@ -871,7 +871,7 @@ namespace Pulsar4X.ECSLib
         internal static string GetWorkingDirectory()
         {
             // get list of default sub-directories:
-            string workingDirectory = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath);
+            string workingDirectory = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().Location).LocalPath);
             if (workingDirectory == null)
             {
                 throw new DirectoryNotFoundException("SerializationManager could not find/access the executable's directory.");


### PR DESCRIPTION
Use Location property instead of CodeBase property in GetWorkingDirectory(). Location property handles weird characters in the file path like # while CodeBase causes the file path to be truncated improperly.