### PR TITLE
chore: Change launch.json to NET 6

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,9 +9,9 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceFolder}/Pulsar4X/Pulsar4X.ImGuiNetUI/bin/Debug/netcoreapp3.1/Pulsar4X.ImGuiNetUI.dll",
+            "program": "${workspaceFolder}/Pulsar4X/Pulsar4X.ImGuiNetUI/bin/Debug/net6.0/Pulsar4X.ImGuiNetUI.dll",
             "args": [],
-            "cwd": "${workspaceFolder}/Pulsar4X/Pulsar4X.ImGuiNetUI/bin/Debug/netcoreapp3.1",
+            "cwd": "${workspaceFolder}/Pulsar4X/Pulsar4X.ImGuiNetUI/bin/Debug/net6.0",
             "stopAtEntry": false,
             "console": "internalConsole"
         }


### PR DESCRIPTION
Map binary paths in `launch.json` for VSCode to corespond actual paths