### PR TITLE
Update ImGui.NET version to 1.88.0

### DIFF
--- a/Pulsar4X/Pulsar4X.Client/Pulsar4X.Client.csproj
+++ b/Pulsar4X/Pulsar4X.Client/Pulsar4X.Client.csproj
@@ -86,7 +86,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ImGui.NET" Version="1.87.3" />
+    <PackageReference Include="ImGui.NET" Version="1.88.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="7.0.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
I tried running Pulsar4x on a MacBook Air 2020 (m1 processor, macOS Sonoma) using this tutorial: https://github.com/Pulsar4xDevs/Pulsar4x/wiki/Compilation#mac-1.

With the update of ImGui.NET to version 1.88.0, we should get rid of steps 4-6.
PR that fixes this behavior in ImGui.NET: https://github.com/ImGuiNET/ImGui.NET/pull/318

After the update I tried running the game on both Mac and Windows, at a quick glance I found no problems.