### PR TITLE
Error thrown now says what file could not be found 

### DIFF
--- a/Pulsar4X/GameEngine/Damage/DamageComplex/DamageTools.cs
+++ b/Pulsar4X/GameEngine/Damage/DamageComplex/DamageTools.cs
@@ -78,7 +78,9 @@ namespace Pulsar4X.Damage
 
 
             if(!File.Exists(file))
-                throw new FileNotFoundException();
+            {
+                throw new FileNotFoundException("Could not find bitmap", file);
+            }
 
             byte[] bmpBytes = File.ReadAllBytes(file);
             (int offset,int size)[] headerDef = new (int,int)[12];


### PR DESCRIPTION
Preiviously when the Client could not find a file it would throw an "COuld not find file error", but didn't tell the end user what file was not found. Now it does in this location