### PR TITLE
Fixing imgui crash when clicking on planets on map

### DIFF
--- a/Pulsar4X/Pulsar4X.Client/IMGUISDL/SDL3Window.cs
+++ b/Pulsar4X/Pulsar4X.Client/IMGUISDL/SDL3Window.cs
@@ -102,6 +102,9 @@ namespace Pulsar4X.Client
 
         public SDL.WindowFlags Flags => (SDL.WindowFlags) SDL.GetWindowFlags(Window);
         public bool IsAlive { get; set; } = false;
+        
+        protected bool _ctrlPressed = false;
+        public bool IsCtrlPressed => _ctrlPressed;
 
         public SDL3Window(
             string title = _defaultTitle,
@@ -181,6 +184,10 @@ namespace Pulsar4X.Client
                 SDL.StartTextInput(Window);
             else if(!ImGui.GetIO().WantTextInput && SDL.TextInputActive(Window))
                 SDL.StopTextInput(Window);
+
+            // Update Ctrl key state
+            var keyMods = SDL.GetModState();
+            _ctrlPressed = keyMods.HasFlag(SDL.Keymod.LCtrl) || keyMods.HasFlag(SDL.Keymod.RCtrl);
 
             while(SDL.PollEvent(out var ev))
             {

--- a/Pulsar4X/Pulsar4X.Client/PulsarMainWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/PulsarMainWindow.cs
@@ -134,9 +134,7 @@ namespace Pulsar4X.Client
 
                 if (mouseDownX == mouseX && mouseDownY == mouseY) //click on map.
                 {
-                    var keyMods = SDL.GetModState();
-                    bool ctrlPressed = keyMods.HasFlag(SDL.Keymod.LCtrl) || keyMods.HasFlag(SDL.Keymod.RCtrl);
-                    _state.MapClicked(_state.Camera.WorldCoordinate_m(mouseX, mouseY), MouseButtons.Primary, ctrlPressed); //sdl and imgu use different numbers for buttons.
+                    _state.MapClicked(_state.Camera.WorldCoordinate_m(mouseX, mouseY), MouseButtons.Primary); //sdl and imgu use different numbers for buttons.
                 }
             }
 
@@ -154,9 +152,7 @@ namespace Pulsar4X.Client
 
                 if (mouseDownAltX == mouseX && mouseDownAltY == mouseY) //click on map.
                 {
-                    var keyMods = SDL.GetModState();
-                    bool ctrlPressed = keyMods.HasFlag(SDL.Keymod.LCtrl) || keyMods.HasFlag(SDL.Keymod.RCtrl);
-                    _state.MapClicked(_state.Camera.WorldCoordinate_m(mouseX, mouseY), MouseButtons.Alt, ctrlPressed);//sdl and imgu use different numbers for buttons.
+                    _state.MapClicked(_state.Camera.WorldCoordinate_m(mouseX, mouseY), MouseButtons.Alt);//sdl and imgu use different numbers for buttons.
                 }
             }
 

--- a/Pulsar4X/Pulsar4X.Client/PulsarMainWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/PulsarMainWindow.cs
@@ -134,7 +134,9 @@ namespace Pulsar4X.Client
 
                 if (mouseDownX == mouseX && mouseDownY == mouseY) //click on map.
                 {
-                    _state.MapClicked(_state.Camera.WorldCoordinate_m(mouseX, mouseY), MouseButtons.Primary); //sdl and imgu use different numbers for buttons.
+                    var keyMods = SDL.GetModState();
+                    bool ctrlPressed = keyMods.HasFlag(SDL.Keymod.LCtrl) || keyMods.HasFlag(SDL.Keymod.RCtrl);
+                    _state.MapClicked(_state.Camera.WorldCoordinate_m(mouseX, mouseY), MouseButtons.Primary, ctrlPressed); //sdl and imgu use different numbers for buttons.
                 }
             }
 
@@ -152,7 +154,9 @@ namespace Pulsar4X.Client
 
                 if (mouseDownAltX == mouseX && mouseDownAltY == mouseY) //click on map.
                 {
-                    _state.MapClicked(_state.Camera.WorldCoordinate_m(mouseX, mouseY), MouseButtons.Alt);//sdl and imgu use different numbers for buttons.
+                    var keyMods = SDL.GetModState();
+                    bool ctrlPressed = keyMods.HasFlag(SDL.Keymod.LCtrl) || keyMods.HasFlag(SDL.Keymod.RCtrl);
+                    _state.MapClicked(_state.Camera.WorldCoordinate_m(mouseX, mouseY), MouseButtons.Alt, ctrlPressed);//sdl and imgu use different numbers for buttons.
                 }
             }
 

--- a/Pulsar4X/Pulsar4X.Client/State/GlobalUIState.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/GlobalUIState.cs
@@ -259,7 +259,7 @@ namespace Pulsar4X.Client
         }
 
         //checks wether the planet icon is clicked
-        internal void MapClicked(Orbital.Vector3 worldCoord, MouseButtons button)
+        internal void MapClicked(Orbital.Vector3 worldCoord, MouseButtons button, bool ctrlPressed = false)
         {
             if (button == MouseButtons.Primary)
                 LastWorldPointClicked_m = worldCoord;
@@ -304,10 +304,7 @@ namespace Pulsar4X.Client
                     //int distComp = (int)Math.Sqrt(Math.Pow(50,2)/2);
 
                     if(closestEntityDistInM <= closestEntity.GetDataBlob<MassVolumeDB>().RadiusInM || Camera.WorldDistance_AU(minPixelRadius) >=  Distance.MToAU(closestEntityDistInM)){
-                        ImGui.Begin("--crash fixer--(this menu`s whole purpose is preventing a ImGui global state related game crash)");
-
-                        EntityClicked(closestEntity.Id, SelectedStarSystemId, button);
-                        ImGui.End();
+                        EntityClicked(closestEntity.Id, SelectedStarSystemId, button, ctrlPressed);
 
                         if(button == MouseButtons.Alt){
                             _lastContextMenuOpenedEntityGuid = closestEntity.Id;
@@ -326,7 +323,7 @@ namespace Pulsar4X.Client
             ActiveWindow?.EntitySelectedAsPrimary(PrimaryEntity);
         }
 
-        internal void EntityClicked(int entityGuid, string starSys, MouseButtons button)
+        internal void EntityClicked(int entityGuid, string starSys, MouseButtons button, bool ctrlPressed = false)
         {
             if(SelectedSysMapRender == null) throw new NullReferenceException("SelectedSysMapRender is null");
 
@@ -360,7 +357,7 @@ namespace Pulsar4X.Client
                 }
                 EntityWindows[entityGuid].ToggleActive();
 
-                if(!ImGui.GetIO().KeyCtrl)
+                if(!ctrlPressed)
                 {
                     foreach(var (id, window) in EntityWindows)
                     {
@@ -372,10 +369,10 @@ namespace Pulsar4X.Client
             }
         }
 
-        internal void EntityClicked(EntityState entityState, MouseButtons button)
+        internal void EntityClicked(EntityState entityState, MouseButtons button, bool ctrlPressed = false)
         {
             if(entityState.StarSystemId == null) throw new NullReferenceException("StarSystemId is null");
-            EntityClicked(entityState.Id, entityState.StarSystemId, button);
+            EntityClicked(entityState.Id, entityState.StarSystemId, button, ctrlPressed);
         }
     }
 

--- a/Pulsar4X/Pulsar4X.Client/State/GlobalUIState.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/GlobalUIState.cs
@@ -259,7 +259,7 @@ namespace Pulsar4X.Client
         }
 
         //checks wether the planet icon is clicked
-        internal void MapClicked(Orbital.Vector3 worldCoord, MouseButtons button, bool ctrlPressed = false)
+        internal void MapClicked(Orbital.Vector3 worldCoord, MouseButtons button)
         {
             if (button == MouseButtons.Primary)
                 LastWorldPointClicked_m = worldCoord;
@@ -304,7 +304,7 @@ namespace Pulsar4X.Client
                     //int distComp = (int)Math.Sqrt(Math.Pow(50,2)/2);
 
                     if(closestEntityDistInM <= closestEntity.GetDataBlob<MassVolumeDB>().RadiusInM || Camera.WorldDistance_AU(minPixelRadius) >=  Distance.MToAU(closestEntityDistInM)){
-                        EntityClicked(closestEntity.Id, SelectedStarSystemId, button, ctrlPressed);
+                        EntityClicked(closestEntity.Id, SelectedStarSystemId, button);
 
                         if(button == MouseButtons.Alt){
                             _lastContextMenuOpenedEntityGuid = closestEntity.Id;
@@ -323,7 +323,7 @@ namespace Pulsar4X.Client
             ActiveWindow?.EntitySelectedAsPrimary(PrimaryEntity);
         }
 
-        internal void EntityClicked(int entityGuid, string starSys, MouseButtons button, bool ctrlPressed = false)
+        internal void EntityClicked(int entityGuid, string starSys, MouseButtons button)
         {
             if(SelectedSysMapRender == null) throw new NullReferenceException("SelectedSysMapRender is null");
 
@@ -357,7 +357,7 @@ namespace Pulsar4X.Client
                 }
                 EntityWindows[entityGuid].ToggleActive();
 
-                if(!ctrlPressed)
+                if(!ViewPort.IsCtrlPressed)
                 {
                     foreach(var (id, window) in EntityWindows)
                     {
@@ -369,10 +369,10 @@ namespace Pulsar4X.Client
             }
         }
 
-        internal void EntityClicked(EntityState entityState, MouseButtons button, bool ctrlPressed = false)
+        internal void EntityClicked(EntityState entityState, MouseButtons button)
         {
             if(entityState.StarSystemId == null) throw new NullReferenceException("StarSystemId is null");
-            EntityClicked(entityState.Id, entityState.StarSystemId, button, ctrlPressed);
+            EntityClicked(entityState.Id, entityState.StarSystemId, button);
         }
     }
 


### PR DESCRIPTION
claude-4-sonnet says:

## Summary of the Fix

The problem was that the `ImGui.Begin("--crash fixer--...")` call was a hack that wasn't properly addressing the root cause. The real issue was that `ImGui.GetIO().KeyCtrl` was being called in the `EntityClicked` method outside of the proper ImGui frame scope, which caused the assertion `g.WithinFrameScope` to fail.

### What I fixed:

1. **Removed the hacky ImGui.Begin/End calls** that were just masking the problem
2. **Captured the Ctrl key state using SDL** at the proper time (during mouse event handling)
3. **Passed the Ctrl state as a parameter** through the call chain instead of querying ImGui later
4. **Updated method signatures** to accept the `ctrlPressed` parameter with backward compatibility

### The changes made:

1. **PulsarMainWindow.cs**: Capture Ctrl key state using `SDL.GetModState()` and pass it to `MapClicked()`
2. **GlobalUIState.cs**: 
   - Updated `MapClicked()` to accept `ctrlPressed` parameter
   - Updated `EntityClicked()` methods to accept `ctrlPressed` parameter  
   - Replaced `ImGui.GetIO().KeyCtrl` with the passed `ctrlPressed` parameter
   - Removed the problematic ImGui.Begin/End hack

This fix ensures that:
- **No ImGui calls happen outside the frame scope**
- **Ctrl key detection still works correctly** for multi-selecting entity windows
- **The code is more robust** and follows proper patterns
- **Backward compatibility is maintained** with default parameter values

The fix should completely resolve the crash you were experiencing when clicking on planets while maintaining all the existing functionality.