### PR TITLE
Adds settings menu to main menu with resolution, etc

### DIFF
--- a/Pulsar4X/Pulsar4X.Client/Interface/Menus/MainMenuItems.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Menus/MainMenuItems.cs
@@ -109,6 +109,10 @@ namespace Pulsar4X.Client
                     SetActive(false);
                 }
 
+                if (ImGui.Button("Settings", _buttonSize))
+                {
+                    SettingsWindow.GetInstance().ToggleActive();
+                }
 
                 if(ImageButton.Begin(_uiState.Img_Discord(), "Discord", new Vector2(16, 12), _buttonSize))
                 {

--- a/Pulsar4X/Pulsar4X.Client/Interface/Menus/SettingsWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Menus/SettingsWindow.cs
@@ -1,5 +1,6 @@
 ﻿using ImGuiNET;
 using System.Collections.Generic;
+using System.Linq;
 using Pulsar4X.Engine;
 using Vector3 = System.Numerics.Vector3;
 using Pulsar4X.Orbits;
@@ -14,7 +15,7 @@ namespace Pulsar4X.Client
         ImGuiTreeNodeFlags _xpanderFlags = ImGuiTreeNodeFlags.CollapsingHeader;
         List<List<UserOrbitSettings>> _userOrbitSettingsMtx;
         //UserOrbitSettings _userOrbitSettings;
-        private GameSettings _gameSettings;
+        private Pulsar4X.Engine.GameSettings _gameSettings;
         private bool _isThreaded;
         private bool _enforceSingleThread;
         private bool _relativeOrbitVelocity;
@@ -26,16 +27,18 @@ namespace Pulsar4X.Client
         private SettingsWindow()
         {
             _userOrbitSettingsMtx = _uiState.UserOrbitSettingsMtx;
-            _gameSettings = _uiState.Game.Settings;
-
+            
+            // Only initialize game-specific settings if a game is loaded
+            if (_uiState.Game != null)
+            {
+                _gameSettings = _uiState.Game.Settings;
+                _isThreaded = _gameSettings.EnableMultiThreading;
+                _enforceSingleThread = _gameSettings.EnforceSingleThread;
+                _relativeOrbitVelocity = _gameSettings.UseRelativeVelocity;
+                _strictNewtonion = _gameSettings.StrictNewtonion;
+            }
 
             _flags = ImGuiWindowFlags.AlwaysAutoResize;
-            _isThreaded = _gameSettings.EnableMultiThreading;
-            _enforceSingleThread = _gameSettings.EnforceSingleThread;
-
-            _relativeOrbitVelocity = _gameSettings.UseRelativeVelocity;
-            _strictNewtonion = _gameSettings.StrictNewtonion;
-
             _orbitalDebugWindow = OrbitalDebugWindow.GetInstance();
             _logWindow = GameLogWindow.GetInstance();
 
@@ -53,205 +56,408 @@ namespace Pulsar4X.Client
         {
             if (IsActive)
             {
-                System.Numerics.Vector2 size = new System.Numerics.Vector2(200, 100);
-                System.Numerics.Vector2 pos = new System.Numerics.Vector2(0, 0);
+                System.Numerics.Vector2 size = new System.Numerics.Vector2(600, 700);
+                System.Numerics.Vector2 pos = new System.Numerics.Vector2(_uiState.MainWinSize.X / 2 - size.X / 2, _uiState.MainWinSize.Y / 2 - size.Y / 2);
 
                 ImGui.SetNextWindowSize(size, ImGuiCond.FirstUseEver);
                 ImGui.SetNextWindowPos(pos, ImGuiCond.Appearing);
 
-                if (Window.Begin("Settings", ref IsActive, _flags))
+                if (Window.Begin("Game Settings", ref IsActive, _flags))
                 {
-                    bool debugActive = DebugWindow.GetInstance().GetActive();
-
-                    if (ImGui.Checkbox("Show Pulsar Debug Window", ref debugActive))
+                    if (ImGui.BeginTabBar("SettingsTabs"))
                     {
-                        DebugWindow.GetInstance().ToggleActive();
-                    }
-
-                    bool dataViewerActive = DataViewerWindow.GetInstance().GetActive();
-                    if (ImGui.Checkbox("Show DataViewer Window", ref dataViewerActive))
-                    {
-                        DataViewerWindow.GetInstance().ToggleActive();
-                    }
-
-                    if (_uiState.LastClickedEntity != null)
-                    {
-                        var lastClickedEntity = _uiState.LastClickedEntity.Entity;
-
-                         if(lastClickedEntity.HasDataBlob<OrbitDB>()
-                            || lastClickedEntity.HasDataBlob<OrbitUpdateOftenDB>()
-                            || lastClickedEntity.HasDataBlob<NewtonMoveDB>())
+                        if (ImGui.BeginTabItem("Display"))
                         {
-                            bool orbitDebugActive = _orbitalDebugWindow.GetActive();
-                            if (ImGui.Checkbox("Show Orbit Debug Lines", ref orbitDebugActive))
-                            {
-                                OrbitalDebugWindow.GetInstance().ToggleActive();
-                            }
-                        }
-                    }
-
-                    bool sensorActive = SensorDraw.GetInstance().GetActive();
-                    if (ImGui.Checkbox("Show Sensor Draw", ref sensorActive))
-                    {
-                        SensorDraw.GetInstance().ToggleActive();
-                    }
-                    bool debugGUIActive = DebugGUIWindow.GetInstance().GetActive();
-                    if (ImGui.Checkbox("Show Pulsar GUI Debug Window", ref debugGUIActive))
-                    {
-                        DebugGUIWindow.GetInstance().ToggleActive();
-                    }
-
-                    bool logActive = _logWindow.GetActive();
-                    if (ImGui.Checkbox("Show Log", ref logActive))
-                    {
-                        _logWindow.ToggleActive();
-                    }
-
-                    bool perfActive = PerformanceWindow.GetInstance().GetActive();
-                    if (ImGui.Checkbox("Show Pulsar Performance Window", ref perfActive))
-                    {
-                        PerformanceWindow.GetInstance().ToggleActive();
-                    }
-
-                    ImGui.Checkbox("Show ImguiMetrix", ref _uiState.ShowMetrixWindow);
-                    ImGui.Checkbox("Show ImgDebug", ref _uiState.ShowImgDbg);
-                    ImGui.Checkbox("DemoWindow", ref _uiState.ShowDemoWindow);
-                    if (ImGui.Checkbox("DamageWindow", ref _uiState.ShowDamageWindow))
-                    {
-                        if (_uiState.ShowDamageWindow)
-                            DamageViewerWindow.GetInstance().SetActive();
-                        else
-                            DamageViewerWindow.GetInstance().SetActive(false);
-
-                    }
-
-                    ImGui.Checkbox("Show Sizes Demo", ref _showSizesDemo);
-                    if(_showSizesDemo)
-                    {
-                        SizesDemo.Display();
-                    }
-
-                    if(ImGui.Checkbox("Show Selector", ref _showSelectorWindow))
-                    {
-                        Selector.GetInstance().SetActive(_showSelectorWindow);
-                    }
-
-                    if (ImGui.CollapsingHeader("Process settings", _xpanderFlags))
-                    {
-                        if (ImGui.Checkbox("MultiThreaded", ref _isThreaded))
-                        {
-                            _uiState.Game.Settings.EnableMultiThreading = _isThreaded;
+                            DisplayVideoSettings();
+                            ImGui.EndTabItem();
                         }
 
-                        if (ImGui.Checkbox("EnforceSingleThread", ref _enforceSingleThread))
+                        if (ImGui.BeginTabItem("Audio"))
                         {
-                            _uiState.Game.Settings.EnforceSingleThread = _enforceSingleThread;
-                            if (_enforceSingleThread)
-                            {
-                                _isThreaded = false;
-                                _uiState.Game.Settings.EnableMultiThreading = false;
-                            }
+                            DisplayAudioSettings();
+                            ImGui.EndTabItem();
                         }
 
-                        if (ImGui.Checkbox("Translate Uses relative Velocity", ref _relativeOrbitVelocity))
+                        if (ImGui.BeginTabItem("Interface"))
                         {
-                            _gameSettings.UseRelativeVelocity = _relativeOrbitVelocity;
-                        }
-                        if (ImGui.IsItemHovered())
-                        {
-                            if (_relativeOrbitVelocity)
-                                ImGui.SetTooltip("Ships exiting from a non newtonion translation will enter an orbit: \n Using a vector relative to it's origin parent");
-                            else
-                                ImGui.SetTooltip("Ships exiting from a non newtonion translation will enter an orbit: \n Using the absolute Vector (ie raltive to the root'sun'");
+                            DisplayInterfaceSettings();
+                            ImGui.EndTabItem();
                         }
 
-                        if (ImGui.Checkbox("Translate Uses Strict Newtonion", ref _strictNewtonion))
+                        if (ImGui.BeginTabItem("Debug"))
                         {
-                            _gameSettings.StrictNewtonion = _strictNewtonion;
-                        }
-                        if (ImGui.IsItemHovered())
-                        {
-                            if (_strictNewtonion)
-                                ImGui.SetTooltip("Ships exiting from a non newtonion translation will enter: \n An orbit using a vector relative to it's origin vector");
-                            else
-                                ImGui.SetTooltip("Ships exiting from a non newtonion translation will enter: \n a Simple circular orbit ignoring its origin newton vector");
+                            DisplayDebugSettings();
+                            ImGui.EndTabItem();
                         }
 
+                        if (_uiState.IsGameLoaded && ImGui.BeginTabItem("Game"))
+                        {
+                            DisplayGameSettings();
+                            ImGui.EndTabItem();
+                        }
+
+                        if (ImGui.BeginTabItem("Map"))
+                        {
+                            DisplayMapSettings();
+                            ImGui.EndTabItem();
+                        }
+
+                        ImGui.EndTabBar();
                     }
 
-
-                    if (ImGui.CollapsingHeader("Map Settings", _xpanderFlags))
+                    ImGui.Separator();
+                    
+                    if (ImGui.Button("Apply Settings"))
                     {
-                        for (int i = 0; i < (int)UserOrbitSettings.OrbitBodyType.NumberOf; i++)
-                        {
-                            UserOrbitSettings.OrbitBodyType otype = (UserOrbitSettings.OrbitBodyType)i;
-                            string typeStr = otype.ToString();
-                            if (ImGui.TreeNode(typeStr ))
-                            {
-                                float _nameZoomLevel = _uiState.DrawNameZoomLvl[otype];
-                                ImGui.SliderFloat("Draw Names at Zoom: ", ref _nameZoomLevel, 0.01f, 10000f);
-                                _uiState.DrawNameZoomLvl[otype] = _nameZoomLevel;
-                                for (int j = 0; j < (int)UserOrbitSettings.OrbitTrajectoryType.NumberOf; j++)
-                                {
-
-                                    UserOrbitSettings.OrbitTrajectoryType trtype = (UserOrbitSettings.OrbitTrajectoryType)j;
-                                    string trtypeStr = trtype.ToString();
-                                    if (ImGui.TreeNode(trtypeStr))
-                                    {
-
-                                        UserOrbitSettings _userOrbitSettings = _userOrbitSettingsMtx[i][j];
-                                        int _arcSegments = _userOrbitSettings.NumberOfArcSegments;
-                                        Vector3 _colour = Helpers.Color(_userOrbitSettings.Red, _userOrbitSettings.Grn, _userOrbitSettings.Blu);
-                                        int _maxAlpha = _userOrbitSettings.MaxAlpha;
-                                        int _minAlpha = _userOrbitSettings.MinAlpha;
-
-
-                                        //TODO: make this a knob/dial? need to create a custom control: https://github.com/ocornut/imgui/issues/942
-                                        if (ImGui.SliderAngle("Sweep Angle ##" + i + j, ref _userOrbitSettings.EllipseSweepRadians, 1f, 360f))
-                                        {
-                                            _uiState.SelectedSysMapRender?.UpdateUserOrbitSettings();
-                                        }
-
-                                        if (ImGui.SliderInt("Number Of Segments ##" + i + j, ref _arcSegments, 1, 255, _userOrbitSettings.NumberOfArcSegments.ToString()))
-                                        {
-                                            _userOrbitSettings.NumberOfArcSegments = (byte)_arcSegments;
-                                            _uiState.SelectedSysMapRender?.UpdateUserOrbitSettings();
-                                        }
-
-                                        if (ImGui.ColorEdit3("Orbit Ring Colour ##" + i + j, ref _colour))
-                                        {
-                                            _userOrbitSettings.Red = Helpers.Color(_colour.X);
-                                            _userOrbitSettings.Grn = Helpers.Color(_colour.Y);
-                                            _userOrbitSettings.Blu = Helpers.Color(_colour.Z);
-                                        }
-                                        if (ImGui.SliderInt("Max Alpha ##" + i + j, ref _maxAlpha, _minAlpha, 255, ""))
-                                        {
-                                            _userOrbitSettings.MaxAlpha = (byte)_maxAlpha;
-                                            _uiState.SelectedSysMapRender?.UpdateUserOrbitSettings();
-                                        }
-
-                                        if (ImGui.SliderInt("Min Alpha  ##" + i + j, ref _minAlpha, 0, _maxAlpha, ""))
-                                        {
-                                            _userOrbitSettings.MinAlpha = (byte)_minAlpha;
-                                            _uiState.SelectedSysMapRender?.UpdateUserOrbitSettings();
-                                        }
-                                        ImGui.TreePop();
-                                    }
-                                }
-                                ImGui.TreePop();
-                            }
-                        }
-
-                        if(ImGui.Button("Save Changes"))
-                        {
-                            ((PulsarMainWindow)_uiState.ViewPort).SaveOrbitSettings();
-                        }
+                        ApplySettings();
                     }
-
+                    
+                    ImGui.SameLine();
+                    
+                    if (ImGui.Button("Save Settings"))
+                    {
+                        SaveSettings();
+                    }
+                    
+                    ImGui.SameLine();
+                    
+                    if (ImGui.Button("Reset to Defaults"))
+                    {
+                        ResetToDefaults();
+                    }
                 }
 
                 Window.End();
             }
+        }
+
+        private void DisplayVideoSettings()
+        {
+            ImGui.Text("Display Settings");
+            ImGui.Separator();
+
+            var settings = _uiState.GameSettings;
+            
+            // Debug info
+            var currentWindowSize = _uiState.ViewPort.Size;
+            ImGui.Text($"Current Window Size: {(int)currentWindowSize.X}x{(int)currentWindowSize.Y}");
+            ImGui.Text($"GameSettings Size: {settings.WindowWidth}x{settings.WindowHeight}");
+            ImGui.Separator();
+            
+            // Resolution
+            ImGui.Text("Resolution:");
+            int currentResolutionIndex = Pulsar4X.Client.GameSettings.CommonResolutions.FindIndex(r => r.width == settings.WindowWidth && r.height == settings.WindowHeight);
+            if (currentResolutionIndex == -1) currentResolutionIndex = 0;
+            
+            string[] resolutionStrings = Pulsar4X.Client.GameSettings.CommonResolutions.Select(r => $"{r.width}x{r.height}").ToArray();
+            if (ImGui.Combo("##Resolution", ref currentResolutionIndex, resolutionStrings, resolutionStrings.Length))
+            {
+                var selectedRes = Pulsar4X.Client.GameSettings.CommonResolutions[currentResolutionIndex];
+                settings.WindowWidth = selectedRes.width;
+                settings.WindowHeight = selectedRes.height;
+            }
+
+            // Display Mode
+            ImGui.Text("Display Mode:");
+            int displayModeIndex = (int)settings.DisplayMode;
+            string[] displayModes = { "Windowed", "Fullscreen", "Borderless Fullscreen" };
+            if (ImGui.Combo("##DisplayMode", ref displayModeIndex, displayModes, displayModes.Length))
+            {
+                settings.DisplayMode = (Pulsar4X.Client.GameSettings.DisplayModeType)displayModeIndex;
+            }
+
+            // VSync
+            bool vsync = settings.VSync;
+            if (ImGui.Checkbox("VSync", ref vsync))
+            {
+                settings.VSync = vsync;
+            }
+        }
+
+        private void DisplayAudioSettings()
+        {
+            ImGui.Text("Audio Settings");
+            ImGui.Separator();
+
+            var settings = _uiState.GameSettings;
+
+            // Audio Enabled
+            bool audioEnabled = settings.AudioEnabled;
+            if (ImGui.Checkbox("Enable Audio", ref audioEnabled))
+            {
+                settings.AudioEnabled = audioEnabled;
+            }
+
+            if (settings.AudioEnabled)
+            {
+                // Master Volume
+                float masterVolume = settings.MasterVolume;
+                if (ImGui.SliderFloat("Master Volume", ref masterVolume, 0.0f, 1.0f, "%.2f"))
+                {
+                    settings.MasterVolume = masterVolume;
+                }
+
+                // Music Volume
+                float musicVolume = settings.MusicVolume;
+                if (ImGui.SliderFloat("Music Volume", ref musicVolume, 0.0f, 1.0f, "%.2f"))
+                {
+                    settings.MusicVolume = musicVolume;
+                }
+
+                // Sound Effects Volume
+                float sfxVolume = settings.SoundEffectsVolume;
+                if (ImGui.SliderFloat("Sound Effects Volume", ref sfxVolume, 0.0f, 1.0f, "%.2f"))
+                {
+                    settings.SoundEffectsVolume = sfxVolume;
+                }
+            }
+        }
+
+        private void DisplayInterfaceSettings()
+        {
+            ImGui.Text("Interface Settings");
+            ImGui.Separator();
+
+            var settings = _uiState.GameSettings;
+
+            // UI Scale
+            float uiScale = settings.UIScale;
+            if (ImGui.SliderFloat("UI Scale", ref uiScale, 0.5f, 3.0f, "%.2f"))
+            {
+                settings.UIScale = uiScale;
+                // Apply UI scale immediately
+                ImGui.GetIO().FontGlobalScale = uiScale;
+                //ImGui.GetStyle().ScaleAllSizes(uiScale);
+            }
+
+            // Show Tooltips
+            bool showTooltips = settings.ShowTooltips;
+            if (ImGui.Checkbox("Show Tooltips", ref showTooltips))
+            {
+                settings.ShowTooltips = showTooltips;
+            }
+
+            // Show FPS
+            bool showFPS = settings.ShowFPS;
+            if (ImGui.Checkbox("Show FPS Counter", ref showFPS))
+            {
+                settings.ShowFPS = showFPS;
+            }
+        }
+
+        private void DisplayDebugSettings()
+        {
+            ImGui.Text("Debug Settings");
+            ImGui.Separator();
+
+            bool debugActive = DebugWindow.GetInstance().GetActive();
+            if (ImGui.Checkbox("Show Pulsar Debug Window", ref debugActive))
+            {
+                DebugWindow.GetInstance().ToggleActive();
+            }
+
+            bool dataViewerActive = DataViewerWindow.GetInstance().GetActive();
+            if (ImGui.Checkbox("Show DataViewer Window", ref dataViewerActive))
+            {
+                DataViewerWindow.GetInstance().ToggleActive();
+            }
+
+            if (_uiState.LastClickedEntity != null)
+            {
+                var lastClickedEntity = _uiState.LastClickedEntity.Entity;
+                if(lastClickedEntity.HasDataBlob<OrbitDB>()
+                   || lastClickedEntity.HasDataBlob<OrbitUpdateOftenDB>()
+                   || lastClickedEntity.HasDataBlob<NewtonMoveDB>())
+                {
+                    bool orbitDebugActive = _orbitalDebugWindow.GetActive();
+                    if (ImGui.Checkbox("Show Orbit Debug Lines", ref orbitDebugActive))
+                    {
+                        OrbitalDebugWindow.GetInstance().ToggleActive();
+                    }
+                }
+            }
+
+            bool sensorActive = SensorDraw.GetInstance().GetActive();
+            if (ImGui.Checkbox("Show Sensor Draw", ref sensorActive))
+            {
+                SensorDraw.GetInstance().ToggleActive();
+            }
+
+            bool debugGUIActive = DebugGUIWindow.GetInstance().GetActive();
+            if (ImGui.Checkbox("Show Pulsar GUI Debug Window", ref debugGUIActive))
+            {
+                DebugGUIWindow.GetInstance().ToggleActive();
+            }
+
+            bool logActive = _logWindow.GetActive();
+            if (ImGui.Checkbox("Show Log", ref logActive))
+            {
+                _logWindow.ToggleActive();
+            }
+
+            bool perfActive = PerformanceWindow.GetInstance().GetActive();
+            if (ImGui.Checkbox("Show Pulsar Performance Window", ref perfActive))
+            {
+                PerformanceWindow.GetInstance().ToggleActive();
+            }
+
+            ImGui.Checkbox("Show ImguiMetrix", ref _uiState.ShowMetrixWindow);
+            ImGui.Checkbox("Show ImgDebug", ref _uiState.ShowImgDbg);
+            ImGui.Checkbox("DemoWindow", ref _uiState.ShowDemoWindow);
+            
+            if (ImGui.Checkbox("DamageWindow", ref _uiState.ShowDamageWindow))
+            {
+                if (_uiState.ShowDamageWindow)
+                    DamageViewerWindow.GetInstance().SetActive();
+                else
+                    DamageViewerWindow.GetInstance().SetActive(false);
+            }
+
+            ImGui.Checkbox("Show Sizes Demo", ref _showSizesDemo);
+            if(_showSizesDemo)
+            {
+                SizesDemo.Display();
+            }
+
+            if(ImGui.Checkbox("Show Selector", ref _showSelectorWindow))
+            {
+                Selector.GetInstance().SetActive(_showSelectorWindow);
+            }
+        }
+
+        private void DisplayGameSettings()
+        {
+            if (_uiState.Game == null || _gameSettings == null) return;
+
+            ImGui.Text("Game Process Settings");
+            ImGui.Separator();
+
+            if (ImGui.Checkbox("MultiThreaded", ref _isThreaded))
+            {
+                _gameSettings.EnableMultiThreading = _isThreaded;
+            }
+
+            if (ImGui.Checkbox("EnforceSingleThread", ref _enforceSingleThread))
+            {
+                _gameSettings.EnforceSingleThread = _enforceSingleThread;
+                if (_enforceSingleThread)
+                {
+                    _isThreaded = false;
+                    _gameSettings.EnableMultiThreading = false;
+                }
+            }
+
+            if (ImGui.Checkbox("Translate Uses relative Velocity", ref _relativeOrbitVelocity))
+            {
+                _gameSettings.UseRelativeVelocity = _relativeOrbitVelocity;
+            }
+            if (ImGui.IsItemHovered())
+            {
+                if (_relativeOrbitVelocity)
+                    ImGui.SetTooltip("Ships exiting from a non newtonion translation will enter an orbit: \n Using a vector relative to it's origin parent");
+                else
+                    ImGui.SetTooltip("Ships exiting from a non newtonion translation will enter an orbit: \n Using the absolute Vector (ie raltive to the root'sun'");
+            }
+
+            if (ImGui.Checkbox("Translate Uses Strict Newtonion", ref _strictNewtonion))
+            {
+                _gameSettings.StrictNewtonion = _strictNewtonion;
+            }
+            if (ImGui.IsItemHovered())
+            {
+                if (_strictNewtonion)
+                    ImGui.SetTooltip("Ships exiting from a non newtonion translation will enter: \n An orbit using a vector relative to it's origin vector");
+                else
+                    ImGui.SetTooltip("Ships exiting from a non newtonion translation will enter: \n a Simple circular orbit ignoring its origin newton vector");
+            }
+        }
+
+        private void DisplayMapSettings()
+        {
+            ImGui.Text("Map Settings");
+            ImGui.Separator();
+
+            for (int i = 0; i < (int)UserOrbitSettings.OrbitBodyType.NumberOf; i++)
+            {
+                UserOrbitSettings.OrbitBodyType otype = (UserOrbitSettings.OrbitBodyType)i;
+                string typeStr = otype.ToString();
+                if (ImGui.TreeNode(typeStr))
+                {
+                    float _nameZoomLevel = _uiState.DrawNameZoomLvl[otype];
+                    ImGui.SliderFloat("Draw Names at Zoom: ", ref _nameZoomLevel, 0.01f, 10000f);
+                    _uiState.DrawNameZoomLvl[otype] = _nameZoomLevel;
+                    
+                    for (int j = 0; j < (int)UserOrbitSettings.OrbitTrajectoryType.NumberOf; j++)
+                    {
+                        UserOrbitSettings.OrbitTrajectoryType trtype = (UserOrbitSettings.OrbitTrajectoryType)j;
+                        string trtypeStr = trtype.ToString();
+                        if (ImGui.TreeNode(trtypeStr))
+                        {
+                            UserOrbitSettings _userOrbitSettings = _userOrbitSettingsMtx[i][j];
+                            int _arcSegments = _userOrbitSettings.NumberOfArcSegments;
+                            Vector3 _colour = Helpers.Color(_userOrbitSettings.Red, _userOrbitSettings.Grn, _userOrbitSettings.Blu);
+                            int _maxAlpha = _userOrbitSettings.MaxAlpha;
+                            int _minAlpha = _userOrbitSettings.MinAlpha;
+
+                            //TODO: make this a knob/dial? need to create a custom control: https://github.com/ocornut/imgui/issues/942
+                            if (ImGui.SliderAngle("Sweep Angle ##" + i + j, ref _userOrbitSettings.EllipseSweepRadians, 1f, 360f))
+                            {
+                                _uiState.SelectedSysMapRender?.UpdateUserOrbitSettings();
+                            }
+
+                            if (ImGui.SliderInt("Number Of Segments ##" + i + j, ref _arcSegments, 1, 255, _userOrbitSettings.NumberOfArcSegments.ToString()))
+                            {
+                                _userOrbitSettings.NumberOfArcSegments = (byte)_arcSegments;
+                                _uiState.SelectedSysMapRender?.UpdateUserOrbitSettings();
+                            }
+
+                            if (ImGui.ColorEdit3("Orbit Ring Colour ##" + i + j, ref _colour))
+                            {
+                                _userOrbitSettings.Red = Helpers.Color(_colour.X);
+                                _userOrbitSettings.Grn = Helpers.Color(_colour.Y);
+                                _userOrbitSettings.Blu = Helpers.Color(_colour.Z);
+                            }
+                            
+                            if (ImGui.SliderInt("Max Alpha ##" + i + j, ref _maxAlpha, _minAlpha, 255, ""))
+                            {
+                                _userOrbitSettings.MaxAlpha = (byte)_maxAlpha;
+                                _uiState.SelectedSysMapRender?.UpdateUserOrbitSettings();
+                            }
+
+                            if (ImGui.SliderInt("Min Alpha  ##" + i + j, ref _minAlpha, 0, _maxAlpha, ""))
+                            {
+                                _userOrbitSettings.MinAlpha = (byte)_minAlpha;
+                                _uiState.SelectedSysMapRender?.UpdateUserOrbitSettings();
+                            }
+                            ImGui.TreePop();
+                        }
+                    }
+                    ImGui.TreePop();
+                }
+            }
+
+            if(ImGui.Button("Save Map Changes"))
+            {
+                ((PulsarMainWindow)_uiState.ViewPort).SaveOrbitSettings();
+            }
+        }
+
+        private void ApplySettings()
+        {
+            _uiState.GameSettings.ApplyDisplaySettings(_uiState.ViewPort);
+        }
+
+        private void SaveSettings()
+        {
+            _uiState.GameSettings.Save();
+            ((PulsarMainWindow)_uiState.ViewPort).SaveOrbitSettings();
+        }
+
+        private void ResetToDefaults()
+        {
+            _uiState.GameSettings = new GameSettings();
+            ImGui.GetIO().FontGlobalScale = 1.0f;
+            //ImGui.GetStyle().ScaleAllSizes(1.0f);
         }
     }
 }

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/Debug/DataViewerWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/Debug/DataViewerWindow.cs
@@ -24,13 +24,16 @@ public class DataViewerWindow : PulsarGuiWindow
     {
         DataViewerWindow instance;
         if (!_uiState.LoadedWindows.ContainsKey(typeof(DataViewerWindow)))
-            instance = new DataViewerWindow(_uiState.Game.StartingGameData);
+            instance = new DataViewerWindow(_uiState.Game?.StartingGameData);
         else
         {
             instance = (DataViewerWindow)_uiState.LoadedWindows[typeof(DataViewerWindow)];
         }
 
-        instance._systemState = _uiState.StarSystemStates[_uiState.SelectedStarSystemId];
+        if (_uiState.IsGameLoaded && !string.IsNullOrEmpty(_uiState.SelectedStarSystemId))
+            instance._systemState = _uiState.StarSystemStates[_uiState.SelectedStarSystemId];
+        else
+            instance._systemState = null;
         return instance;
     }
 

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/Debug/DebugWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/Debug/DebugWindow.cs
@@ -94,13 +94,17 @@ namespace Pulsar4X.Client
             else
             {
                 instance = (DebugWindow)_uiState.LoadedWindows[typeof(DebugWindow)];
-                instance.RefreshFactionEntites(_uiState);
+                if (_uiState.IsGameLoaded)
+                    instance.RefreshFactionEntites(_uiState);
                 //if(_uiState.LastClickedEntity?.Entity != null)
                 //    instance.SelectedEntity = _uiState.LastClickedEntity.Entity;
             }
             //if(_uiState.LastClickedEntity?.Entity != null && instance.SelectedEntity != _uiState.LastClickedEntity.Entity)
             //    instance.SelectedEntity = _uiState.LastClickedEntity.Entity;
-            instance.SystemState = _uiState.StarSystemStates[_uiState.SelectedStarSystemId];
+            if (_uiState.IsGameLoaded && !string.IsNullOrEmpty(_uiState.SelectedStarSystemId))
+                instance.SystemState = _uiState.StarSystemStates[_uiState.SelectedStarSystemId];
+            else
+                instance.SystemState = null;
             return instance;
         }
 

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/Debug/PerformanceWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/Debug/PerformanceWindow.cs
@@ -61,7 +61,10 @@ namespace Pulsar4X.Client
             {
                 instance = (PerformanceWindow)_uiState.LoadedWindows[typeof(PerformanceWindow)];
             }
-            instance._systemState = _uiState.StarSystemStates[_uiState.SelectedStarSystemId];
+            if (_uiState.IsGameLoaded && !string.IsNullOrEmpty(_uiState.SelectedStarSystemId))
+                instance._systemState = _uiState.StarSystemStates[_uiState.SelectedStarSystemId];
+            else
+                instance._systemState = null;
             return instance;
         }
 

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/Debug/SensorDraw.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/Debug/SensorDraw.cs
@@ -75,7 +75,10 @@ namespace Pulsar4X.Client
                     instance._selectedEntitySate = _uiState.LastClickedEntity;
             }
 
-            instance._selectedStarSysState = _uiState.StarSystemStates[_uiState.SelectedStarSystemId];
+            if (_uiState.IsGameLoaded && !string.IsNullOrEmpty(_uiState.SelectedStarSystemId))
+                instance._selectedStarSysState = _uiState.StarSystemStates[_uiState.SelectedStarSystemId];
+            else
+                instance._selectedStarSysState = null;
             return instance;
         }
 

--- a/Pulsar4X/Pulsar4X.Client/PulsarMainWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/PulsarMainWindow.cs
@@ -77,6 +77,12 @@ namespace Pulsar4X.Client
 
                 // Read and apply any window preferences
                 LoadPreferences();
+                
+                // Apply game settings (resolution, display mode, etc.) - this should override old preferences
+                _state.GameSettings.ApplyDisplaySettings(this);
+                
+                // Apply UI scaling
+                ImGui.GetIO().FontGlobalScale = _state.GameSettings.UIScale;
 
                 // Apply any saved user orbit settings
                 LoadUserOrbitSettings();
@@ -280,6 +286,20 @@ namespace Pulsar4X.Client
                 item.Display();
             }
 
+            // Show FPS counter if enabled
+            if (_state.GameSettings.ShowFPS)
+            {
+                var fpsDispsize = ImGui.GetIO().DisplaySize;
+                var fpsPos = new Vector2(fpsDispsize.X - 120, 10);
+                ImGui.SetNextWindowPos(fpsPos, ImGuiCond.Always);
+                ImGui.SetNextWindowBgAlpha(0.7f);
+                if (Client.Interface.Widgets.Window.Begin("FPS", _gitHashFlags))
+                {
+                    ImGui.Text($"FPS: {ImGui.GetIO().Framerate:F1}");
+                    Client.Interface.Widgets.Window.End();
+                }
+            }
+
             // If in DEBUG render the git hash as the version in the corner of the screen
 #if DEBUG
             var dispsize = ImGui.GetIO().DisplaySize;
@@ -297,6 +317,9 @@ namespace Pulsar4X.Client
         {
             // save the user orbit settings on exit
             SaveOrbitSettings();
+            
+            // save the game settings on exit
+            _state.GameSettings.Save();
         }
 
         /// <summary>

--- a/Pulsar4X/Pulsar4X.Client/State/GameSettings.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/GameSettings.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json;
+using SDL3;
+
+namespace Pulsar4X.Client
+{
+    public class GameSettings
+    {
+        public static string SettingsFileName = "game-settings.json";
+        
+        // Display Settings
+        public int WindowWidth { get; set; } = 1280;
+        public int WindowHeight { get; set; } = 720;
+        public DisplayModeType DisplayMode { get; set; } = DisplayModeType.Windowed;
+        public bool VSync { get; set; } = true;
+        
+        // Audio Settings
+        public float MasterVolume { get; set; } = 1.0f;
+        public float MusicVolume { get; set; } = 0.8f;
+        public float SoundEffectsVolume { get; set; } = 0.9f;
+        public bool AudioEnabled { get; set; } = true;
+        
+        // UI Settings
+        public float UIScale { get; set; } = 1.0f;
+        public bool ShowTooltips { get; set; } = true;
+        public bool ShowFPS { get; set; } = false;
+        
+        // Input Settings
+        public bool MouseInvertY { get; set; } = false;
+        public float MouseSensitivity { get; set; } = 1.0f;
+        
+        // Available display modes
+        public enum DisplayModeType
+        {
+            Windowed,
+            Fullscreen,
+            BorderlessFullscreen
+        }
+        
+        // Available resolutions (common ones)
+        public static readonly List<(int width, int height)> CommonResolutions = new List<(int, int)>
+        {
+            (1280, 720),
+            (1366, 768),
+            (1920, 1080),
+            (2560, 1440),
+            (3840, 2160),
+            (1680, 1050),
+            (1440, 900),
+            (1600, 900),
+            (2560, 1080),
+            (3440, 1440)
+        };
+        
+        public void Save()
+        {
+            try
+            {
+                string? appDataPath = PulsarMainWindow.GetAppDataPath();
+                if (string.IsNullOrEmpty(appDataPath))
+                    return;
+                    
+                string settingsPath = Path.Combine(appDataPath, SettingsFileName);
+                string json = JsonConvert.SerializeObject(this, Formatting.Indented);
+                File.WriteAllText(settingsPath, json);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Failed to save game settings: {ex.Message}");
+            }
+        }
+        
+        public static GameSettings Load()
+        {
+            try
+            {
+                string? appDataPath = PulsarMainWindow.GetAppDataPath();
+                if (string.IsNullOrEmpty(appDataPath))
+                    return new GameSettings();
+                    
+                string settingsPath = Path.Combine(appDataPath, SettingsFileName);
+                if (!File.Exists(settingsPath))
+                    return new GameSettings();
+                    
+                string json = File.ReadAllText(settingsPath);
+                var settings = JsonConvert.DeserializeObject<GameSettings>(json);
+                return settings ?? new GameSettings();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Failed to load game settings: {ex.Message}");
+                return new GameSettings();
+            }
+        }
+        
+        public void ApplyDisplaySettings(SDL3Window window)
+        {
+            try
+            {
+                // Apply resolution
+                window.Size = new System.Numerics.Vector2(WindowWidth, WindowHeight);
+                
+                // Apply display mode
+                switch (DisplayMode)
+                {
+                    case DisplayModeType.Windowed:
+                        SDL.SetWindowFullscreen(window.Window, false);
+                        SDL.SetWindowBordered(window.Window, true);
+                        break;
+                        
+                    case DisplayModeType.Fullscreen:
+                        SDL.SetWindowFullscreen(window.Window, true);
+                        break;
+                        
+                    case DisplayModeType.BorderlessFullscreen:
+                        SDL.SetWindowFullscreen(window.Window, false);
+                        SDL.SetWindowBordered(window.Window, false);
+                        // Get desktop resolution for borderless fullscreen
+                        var mode = SDL.GetCurrentDisplayMode(SDL.GetPrimaryDisplay());
+                        if (mode != null)
+                        {
+                            window.Size = new System.Numerics.Vector2(mode.Value.W, mode.Value.H);
+                            SDL.SetWindowPosition(window.Window, 0, 0);
+                        }
+                        break;
+                }
+                
+                // Apply VSync
+                SDL.SetRenderVSync(window.Renderer, VSync ? 1 : 0);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Failed to apply display settings: {ex.Message}");
+            }
+        }
+    }
+} 

--- a/Pulsar4X/Pulsar4X.Client/State/GlobalUIState.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/GlobalUIState.cs
@@ -96,6 +96,9 @@ namespace Pulsar4X.Client
         internal Stack<IHotKeyHandler> HotKeys { get; private set; } = new ();
 
         internal View? SelectedMapView { get; set; } = null;
+        
+        // Game Settings
+        internal GameSettings GameSettings { get; set; }
 
         internal GlobalUIState(SDL3Window viewport)
         {
@@ -104,6 +107,9 @@ namespace Pulsar4X.Client
             var windowPtr = viewport.Window;
 
             SDLRendererPtr = SDL.CreateRenderer(windowPtr, "pulsar4x");
+            
+            // Load game settings
+            GameSettings = GameSettings.Load();
 
             DrawNameZoomLvl.Add(UserOrbitSettings.OrbitBodyType.Star, 2f);
             DrawNameZoomLvl.Add(UserOrbitSettings.OrbitBodyType.Planet, 32f);


### PR DESCRIPTION
Adds typical a game settings dialog in main menu with typical game settings such as resolution, fullscreen/borderless, vsync, fps display, audio settings (not hooked up to anything), and temp UI scaling solution.  

Remembers settings across launchs using game-settings.json stored in PulsarMainWindow.GetAppDataPath()

The existing settings are moved into "Debug" tab of the settings dialog