### PR TITLE
Add hotkeys for simulation time control.

### DIFF
--- a/Pulsar4X/Pulsar4X.Client/Input/SystemMapHotKeys.cs
+++ b/Pulsar4X/Pulsar4X.Client/Input/SystemMapHotKeys.cs
@@ -11,7 +11,20 @@ public class SystemMapHotKeys : IHotKeyHandler
     {
         if (!ImGui.IsAnyItemActive() && e.Type == (uint)SDL.EventType.KeyUp)
         {
-            if (e.Key.Key == SDL.Keycode.Escape)
+            if (e.Key.Key == SDL.Keycode.Space)
+            {
+                var tc = TimeControl.GetInstance();
+                if((e.Key.Mod & SDL.Keymod.Ctrl) != 0)
+                {
+                    // Ctrl + Space for single step.
+                    tc.OneStepPressed();
+                }
+                else
+                {
+                    tc.PausePlayPressed();
+                }
+            }
+            else if (e.Key.Key == SDL.Keycode.Escape)
             {
                 MainMenuItems.GetInstance().ToggleActive();
             }

--- a/Pulsar4X/Pulsar4X.Client/Interface/HUD/TimeControl.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/HUD/TimeControl.cs
@@ -258,7 +258,7 @@ namespace Pulsar4X.Client
             }
         }
 
-        void PausePlayPressed()
+        internal void PausePlayPressed()
         {
             if (_timeloop == null)
                 return;
@@ -273,7 +273,7 @@ namespace Pulsar4X.Client
             }
         }
 
-        void OneStepPressed()
+        internal void OneStepPressed()
         {
             if (_timeloop == null)
                 return;


### PR DESCRIPTION
- Add hard coded hotkey for simulation Play/Pause bound to `Space`.
- Add hard coded hotkey for single step simulation bound to `Space + Ctrl`,

The PR binds `Space` to play/pause hotkey to improve UX and better mirror other 4x titles with continuous time simulation.