### PR TITLE
Fix minimized fire control.

### DIFF
--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/FireControlWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/FireControlWindow.cs
@@ -87,9 +87,8 @@ namespace Pulsar4X.Client
                 ImGui.NextColumn();
 
                 DisplayTargetColumn();
-
-                Window.End();
             }
+            Window.End();
         }
 
 


### PR DESCRIPTION
When the Fire Control window was minimized, it did not call `Window.End` to close the scope. This caused Debug builds to crash due to failed scope validation, and Release builds to flag the error.