### PR TITLE
Minimize `SystemState` critical section.

### DIFF
--- a/Pulsar4X/Pulsar4X.Client/PulsarMainWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/PulsarMainWindow.cs
@@ -211,12 +211,7 @@ namespace Pulsar4X.Client
                 }
             }
 
-            foreach (var (_, systemState) in _state.StarSystemStates)
-            {
-                systemState.PreFrameSetup();
-            }
-
-            _state.GalacticMap?.Update();
+            _state.Update();
         }
 
         public override void Render()

--- a/Pulsar4X/Pulsar4X.Client/State/EntityState.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/EntityState.cs
@@ -14,6 +14,8 @@ using Pulsar4X.Ships;
 using Pulsar4X.Technology;
 using Pulsar4X.Galaxy;
 using Pulsar4X.Movement;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 
 namespace Pulsar4X.Client
 {
@@ -28,9 +30,20 @@ namespace Pulsar4X.Client
         public IKepler? OrbitIcon;
         public OrbitOrderIcon? DebugOrbitOrder;
         public bool IsDestroyed = false; //currently IsDestroyed = true if moved from one system to another, may need to revisit this.
-        private SafeDictionary<Type, BaseDataBlob> DataBlobs = new ();
-        public SafeList<Message> Changes = new ();
-        public SafeList<Message> _changesNextFrame = new ();
+        private SafeDictionary<Type, BaseDataBlob> DataBlobs = new();
+
+        private class ChangeBuffer
+        {
+            public ConcurrentQueue<Message> ChangeMessages = new();
+        }
+
+        private ChangeBuffer _clientSide = new();
+        private ChangeBuffer _serverSide = new();
+        private readonly object _bufferSwapLock = new();
+
+        private List<Message> _changesThisFrame = new();
+        public IReadOnlyList<Message> Changes => _changesThisFrame;
+
         public CommandReferences? CmdRef;
         internal string? StarSystemId;
         internal UserOrbitSettings.OrbitBodyType BodyType = UserOrbitSettings.OrbitBodyType.Unknown;
@@ -40,7 +53,7 @@ namespace Pulsar4X.Client
             Id = id;
             FactionId = factionId;
 
-            if(entity.Manager != null)
+            if (entity.Manager != null)
             {
                 foreach (var db in entity.Manager.GetAllDataBlobsForEntity(entity.Id))
                 {
@@ -57,7 +70,7 @@ namespace Pulsar4X.Client
 
         public Entity? GetParent()
         {
-            if(HasDataBlob(typeof(PositionDB)))
+            if (HasDataBlob(typeof(PositionDB)))
                 return ((PositionDB)DataBlobs[typeof(PositionDB)]).Parent;
 
             return null;
@@ -85,7 +98,7 @@ namespace Pulsar4X.Client
             Position = sensorContact.Position;
 
             //Name = sensorContact.GetDataBlob<NameDB>().GetName(_uiState.Faction);
-            if(Entity.Manager != null)
+            if (Entity.Manager != null)
             {
                 StarSystem starSys = (StarSystem)Entity.Manager;
                 StarSystemId = starSys.ID;
@@ -98,14 +111,14 @@ namespace Pulsar4X.Client
         {
             get
             {
-                return DataBlobs.ContainsKey(typeof(EntityResearchDB)) ;
+                return DataBlobs.ContainsKey(typeof(EntityResearchDB));
             }
         }
         public bool CanConstruct
         {
             get
             {
-                return DataBlobs.ContainsKey(typeof(IndustryAbilityDB)) ;
+                return DataBlobs.ContainsKey(typeof(IndustryAbilityDB));
             }
         }
 
@@ -118,10 +131,10 @@ namespace Pulsar4X.Client
         {
             Func<Message, bool> filterById = msg => msg.EntityId == Id;
 
-            MessagePublisher.Instance.Subscribe(MessageTypes.EntityRemoved, OnEntityRemoved, filterById);
-            MessagePublisher.Instance.Subscribe(MessageTypes.DBAdded, OnDBAdded, filterById);
-            MessagePublisher.Instance.Subscribe(MessageTypes.DBRemoved, OnDBRemoved, filterById);
-            MessagePublisher.Instance.Subscribe(MessageTypes.EntityHidden, OnEntityRemoved, filterById);
+            MessagePublisher.Instance.Subscribe(MessageTypes.EntityRemoved, EnqueueToBuffer, filterById);
+            MessagePublisher.Instance.Subscribe(MessageTypes.DBAdded, EnqueueToBuffer, filterById);
+            MessagePublisher.Instance.Subscribe(MessageTypes.DBRemoved, EnqueueToBuffer, filterById);
+            MessagePublisher.Instance.Subscribe(MessageTypes.EntityHidden, EnqueueToBuffer, filterById);
         }
 
         /// <summary>
@@ -130,44 +143,76 @@ namespace Pulsar4X.Client
         /// </summary>
         public void Unsubscribe()
         {
-            MessagePublisher.Instance.Unsubscribe(MessageTypes.EntityRemoved, OnEntityRemoved);
-            MessagePublisher.Instance.Unsubscribe(MessageTypes.DBAdded, OnDBAdded);
-            MessagePublisher.Instance.Unsubscribe(MessageTypes.DBRemoved, OnDBRemoved);
-            MessagePublisher.Instance.Unsubscribe(MessageTypes.EntityHidden, OnEntityRemoved);
+            MessagePublisher.Instance.Unsubscribe(MessageTypes.EntityRemoved, EnqueueToBuffer);
+            MessagePublisher.Instance.Unsubscribe(MessageTypes.DBAdded, EnqueueToBuffer);
+            MessagePublisher.Instance.Unsubscribe(MessageTypes.DBRemoved, EnqueueToBuffer);
+            MessagePublisher.Instance.Unsubscribe(MessageTypes.EntityHidden, EnqueueToBuffer);
         }
 
-        Task OnEntityRemoved(Message message)
+        // Enqueues the change messages to the server side buffer.
+        Task EnqueueToBuffer(Message message)
+        {
+            lock (_bufferSwapLock)
+            {
+                _serverSide.ChangeMessages.Enqueue(message);
+            }
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Called every frame.
+        /// </summary>
+        public void Update()
+        {
+            _changesThisFrame.Clear();
+
+            lock (_bufferSwapLock)
+            {
+                (_clientSide, _serverSide) = (_serverSide, _clientSide);
+            }
+
+            while (_clientSide.ChangeMessages.TryDequeue(out var message))
+            {
+                switch (message.MessageType)
+                {
+                    case MessageTypes.EntityRemoved:
+                    case MessageTypes.EntityHidden:
+                        HandleOnEntityRemoved(message);
+                        break;
+                    case MessageTypes.DBAdded:
+                        HandleOnDBAdded(message);
+                        break;
+                    case MessageTypes.DBRemoved:
+                        HandleOnDBRemoved(message);
+                        break;
+                }
+            }
+        }
+
+        private void HandleOnEntityRemoved(Message message)
         {
             DataBlobs.Clear();
             IsDestroyed = true;
-            return Task.CompletedTask;
         }
 
-        Task OnDBAdded(Message message)
+        private void HandleOnDBAdded(Message message)
         {
-            if(message.DataBlob != null)
-            {
-                DataBlobs[message.DataBlob.GetType()] = message.DataBlob;
-                _changesNextFrame.Add(message);
-            }
-            return Task.CompletedTask;
+            if (message.DataBlob is null) return;
+
+            DataBlobs[message.DataBlob.GetType()] = message.DataBlob;
+            _changesThisFrame.Add(message);
         }
 
-        Task OnDBRemoved(Message message)
+        private void HandleOnDBRemoved(Message message)
         {
-            if(message.DataBlob != null)
-            {
-                DataBlobs.Remove(message.DataBlob.GetType());
-                _changesNextFrame.Add(message);
-            }
-            return Task.CompletedTask;
+            if (message.DataBlob is null) return;
+
+            DataBlobs.Remove(message.DataBlob.GetType());
+            _changesThisFrame.Add(message);
         }
 
         public void PostFrameCleanup()
-        {
-            Changes = _changesNextFrame;
-            _changesNextFrame.Clear();
-        }
+        { }
 
         public bool HasDataBlob(Type? type)
         {
@@ -191,7 +236,7 @@ namespace Pulsar4X.Client
 
         public bool TryGetDataBlob<T>([NotNullWhen(true)] out T? value) where T : BaseDataBlob
         {
-            if(HasDataBlob<T>())
+            if (HasDataBlob<T>())
             {
                 value = GetDataBlob<T>();
                 return true;

--- a/Pulsar4X/Pulsar4X.Client/State/GlobalUIState.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/GlobalUIState.cs
@@ -378,7 +378,7 @@ namespace Pulsar4X.Client
             // Update the individual system states.
             foreach (var (_, systemState) in StarSystemStates)
             {
-                systemState.PreFrameSetup();
+                systemState.Update();
             }
 
             // Update the galactic map.

--- a/Pulsar4X/Pulsar4X.Client/State/GlobalUIState.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/GlobalUIState.cs
@@ -15,6 +15,8 @@ using Pulsar4X.Galaxy;
 using Pulsar4X.Movement;
 using Pulsar4X.Orbits;
 using Pulsar4X.Client.Rendering;
+using System.Collections.Concurrent;
+using System.Threading;
 
 namespace Pulsar4X.Client
 {
@@ -49,7 +51,7 @@ namespace Pulsar4X.Client
             {typeof(OrdersListWindow), "Orders Window"},
             {typeof(OrderCreationWindow), "Order Creation"}
         };
-        internal Engine.Game? Game { get; set;}
+        internal Engine.Game? Game { get; set; }
         internal bool IsGameLoaded { get { return Game != null; } }
         internal Entity? Faction { get; set; }
 
@@ -70,27 +72,27 @@ namespace Pulsar4X.Client
         internal bool ShowDamageWindow;
         internal IntPtr SDLRendererPtr { get; private set; }
         internal GalacticMapRender? GalacticMap;
-        internal SafeList<UpdateWindowState> UpdateableWindows = new ();
-        internal DateTime LastGameUpdateTime = new ();
+        internal SafeList<UpdateWindowState> UpdateableWindows = new();
+        internal DateTime LastGameUpdateTime = new();
         internal StarSystem SelectedSystem => StarSystemStates[SelectedStarSystemId].StarSystem;
         internal SystemState SelectedSystemState => StarSystemStates[SelectedStarSystemId];
         internal DateTime SelectedSystemTime => StarSystemStates[SelectedStarSystemId].StarSystem.StarSysDateTime;
-        internal DateTime SelectedSysLastUpdateTime = new ();
+        internal DateTime SelectedSysLastUpdateTime = new();
         internal string SelectedStarSystemId { get; private set; }
         internal SystemMapRendering? SelectedSysMapRender => GalacticMap == null ? null : GalacticMap.SelectedSysMapRender;
         internal DateTime PrimarySystemDateTime;
         internal EntityContextMenu? ContextMenu { get; set; }
-        internal SafeDictionary<string, SystemState> StarSystemStates = new ();
+        internal SafeDictionary<string, SystemState> StarSystemStates = new();
         internal Camera Camera;
         internal SDL3Window ViewPort { get; private set; }
 
-        internal Dictionary<Type, PulsarGuiWindow> LoadedWindows = new ();
-        internal Dictionary<String, NonUniquePulsarGuiWindow> LoadedNonUniqueWindows = new ();
+        internal Dictionary<Type, PulsarGuiWindow> LoadedWindows = new();
+        internal Dictionary<String, NonUniquePulsarGuiWindow> LoadedNonUniqueWindows = new();
         internal PulsarGuiWindow? ActiveWindow { get; set; }
-        internal List<List<UserOrbitSettings>> UserOrbitSettingsMtx = new ();
-        internal Dictionary<UserOrbitSettings.OrbitBodyType, float> DrawNameZoomLvl = new ();
-        internal Dictionary<string, IntPtr> SDLImageDictionary = new ();
-        internal Dictionary<string, int> GLImageDictionary = new ();
+        internal List<List<UserOrbitSettings>> UserOrbitSettingsMtx = new();
+        internal Dictionary<UserOrbitSettings.OrbitBodyType, float> DrawNameZoomLvl = new();
+        internal Dictionary<string, IntPtr> SDLImageDictionary = new();
+        internal Dictionary<string, int> GLImageDictionary = new();
         public event EntityClickedEventHandler? EntityClickedEvent;
         internal EntityState? LastClickedEntity = null;
         internal EntityState? PrimaryEntity { get; private set; }
@@ -99,7 +101,7 @@ namespace Pulsar4X.Client
         internal Dictionary<int, EntityWindow> EntityWindows { get; private set; } = new();
         private string _previousSystemIdBeforeSM = "";
 
-        internal Stack<IHotKeyHandler> HotKeys { get; private set; } = new ();
+        internal Stack<IHotKeyHandler> HotKeys { get; private set; } = new();
 
         // Maneuver node panel for orbit-click placement
         internal ManeuverNodePanel? ManeuverNodePanel { get; set; }
@@ -115,6 +117,17 @@ namespace Pulsar4X.Client
 
         // Game Settings
         internal GameSettings GameSettings { get; set; }
+
+        // TODO: Extract this to a helper class, along with SystemState buffer.
+        // Double buffering events that are received from the engine.
+        private class ChangeBuffer
+        {
+            public ConcurrentQueue<Message> RevealedSystems = new();
+        }
+
+        private ChangeBuffer _clientSide = new();
+        private ChangeBuffer _serverSide = new();
+        private readonly object _bufferSwapLock = new object();
 
         internal GlobalUIState(SDL3Window viewport)
         {
@@ -230,7 +243,8 @@ namespace Pulsar4X.Client
             this.Img_Up();
 
             var mainWin = (PulsarMainWindow)ViewPort;
-            mainWin.MouseButtonDownOccured += (object sender, SDL.Event e) => {
+            mainWin.MouseButtonDownOccured += (object sender, SDL.Event e) =>
+            {
                 if (e.Button.Button == 1)
                 {
                     _mouseDownX = e.Motion.X;
@@ -249,7 +263,8 @@ namespace Pulsar4X.Client
                     }
                 }
             };
-            mainWin.MouseButtonUpOccured += (object sender, SDL.Event e) => {
+            mainWin.MouseButtonUpOccured += (object sender, SDL.Event e) =>
+            {
                 if (e.Button.Button == 1)
                 {
                     Camera.IsGrabbingMap = false;
@@ -274,13 +289,15 @@ namespace Pulsar4X.Client
                     }
                 }
             };
-            mainWin.MouseWheelOccured += (object sender, SDL.Event e) => {
+            mainWin.MouseWheelOccured += (object sender, SDL.Event e) =>
+            {
                 if (e.Wheel.Y > 0)
                     Camera.ZoomIn((int)e.Wheel.MouseX, (int)e.Wheel.MouseY);
                 else if (e.Wheel.Y < 0)
                     Camera.ZoomOut((int)e.Wheel.MouseX, (int)e.Wheel.MouseY);
             };
-            mainWin.MouseMoveOccured += (object sender, SDL.Event e) => {
+            mainWin.MouseMoveOccured += (object sender, SDL.Event e) =>
+            {
                 if (_isDraggingNode)
                 {
                     // Reposition the node along the orbit as the mouse moves
@@ -299,7 +316,7 @@ namespace Pulsar4X.Client
 
         private void DeactivateAllClosableWindows()
         {
-            foreach(var window in LoadedWindows)
+            foreach (var window in LoadedWindows)
             {
                 window.Value.SetActive(false);
             }
@@ -325,15 +342,58 @@ namespace Pulsar4X.Client
             ActiveWindow = null;
         }
 
+        /// <summary>
+        /// Called every frame to update the UI state with the changes from the server.
+        /// </summary>
+        internal void Update()
+        {
+            lock (_bufferSwapLock)
+            {
+                (_clientSide, _serverSide) = (_serverSide, _clientSide);
+            }
+
+            // Handle all buffered events.
+            while (_clientSide.RevealedSystems.TryDequeue(out var message))
+            {
+                if(Game is null || Faction is null)
+                    throw new InvalidOperationException("Revealed systems require a game and faction to be set.");
+
+                if (message.SystemId is null) continue;
+
+                if (!StarSystemStates.ContainsKey(message.SystemId))
+                {
+                    var system = Game?.Systems.FirstOrDefault(s => s.ID.Equals(message.SystemId));
+                    if (system == null)
+                    {
+                        Console.WriteLine($"ERROR: {message.SystemId} was revealed but not found in the game systems.");
+                        continue;
+                    }
+
+                    StarSystemStates[message.SystemId] = new SystemState(system, Faction.Id);
+                }
+
+                OnStarSystemAdded?.Invoke(this, message.SystemId);
+            }
+
+            // Update the individual system states.
+            foreach (var (_, systemState) in StarSystemStates)
+            {
+                systemState.PreFrameSetup();
+            }
+
+            // Update the galactic map.
+            GalacticMap?.Update();
+        }
+
         internal void SetFaction(Entity factionEntity, bool setAsPlayer = false)
         {
-            if(Game == null) throw new NullReferenceException("Game is null");
+            if (Game == null) throw new NullReferenceException("Game is null");
 
-            if(setAsPlayer)
+            if (setAsPlayer)
                 PlayerFaction = factionEntity;
 
             // Remove the old selected system's priority observer
-            if(!string.IsNullOrEmpty(SelectedStarSystemId))
+            if (!string.IsNullOrEmpty(SelectedStarSystemId))
             {
                 StarSystemStates[SelectedStarSystemId].StarSystem.DecrementExternalObserver(true);
             }
@@ -344,12 +404,12 @@ namespace Pulsar4X.Client
             foreach (var guid in factionInfo.KnownSystems)
             {
                 var system = Game.Systems.FirstOrDefault(s => s.ID.Equals(guid));
-                if(system == null) continue;
+                if (system == null) continue;
 
                 StarSystemStates[guid] = new SystemState(system, factionEntity.Id);
 
                 // Notify that the currently selected system is on focus.
-                if(!string.IsNullOrEmpty(SelectedStarSystemId) && SelectedStarSystemId.Equals(guid))
+                if (!string.IsNullOrEmpty(SelectedStarSystemId) && SelectedStarSystemId.Equals(guid))
                 {
                     system.IncrementExternalObserver(true);
                 }
@@ -364,34 +424,26 @@ namespace Pulsar4X.Client
             OnFactionChanged?.Invoke(this);
         }
 
-        internal async Task OnSystemRevealed(Message message)
+        internal Task OnSystemRevealed(Message message)
         {
-            if(Game == null || Faction == null) throw new NullReferenceException("Game or Faction is null");
-
             if (message.SystemId is null)
-                return;
+                return Task.CompletedTask;
 
-            await Task.Run(() => {
-                if(!StarSystemStates.ContainsKey(message.SystemId)){
-                    var system = Game.Systems.FirstOrDefault(s => s.ID.Equals(message.SystemId));
-                    if(system == null)
-                    {
-                        Console.WriteLine($"ERROR: {message.SystemId} was revealed but not found in the game systems.");
-                        return;
-                    }
-                    StarSystemStates[message.SystemId] = new SystemState(system, Faction.Id);
-                }
-                OnStarSystemAdded?.Invoke(this, message.SystemId);
-            });
+            lock (_bufferSwapLock)
+            {
+                _serverSide.RevealedSystems.Enqueue(message);
+            }
+            return Task.CompletedTask;
         }
 
         internal void SetActiveSystem(string activeSysID, bool refresh = false)
         {
-            if(Game == null || Faction == null) throw new NullReferenceException("Game or Faction is null");
+            if (Game == null || Faction == null) throw new NullReferenceException("Game or Faction is null");
 
-            if(!activeSysID.Equals(SelectedStarSystemId) || refresh){
+            if (!activeSysID.Equals(SelectedStarSystemId) || refresh)
+            {
                 // Demote the old system from Foreground to Background
-                if(!string.IsNullOrEmpty(SelectedStarSystemId) && StarSystemStates.ContainsKey(SelectedStarSystemId))
+                if (!string.IsNullOrEmpty(SelectedStarSystemId) && StarSystemStates.ContainsKey(SelectedStarSystemId))
                 {
                     var oldSystem = StarSystemStates[SelectedStarSystemId].StarSystem;
 
@@ -400,7 +452,8 @@ namespace Pulsar4X.Client
                     StarSystemStates[SelectedStarSystemId].SavedCameraState = Camera.SaveState();
                 }
 
-                if(!StarSystemStates.ContainsKey(activeSysID)){
+                if (!StarSystemStates.ContainsKey(activeSysID))
+                {
                     var newSys = new SystemState(Game.Systems.First(s => s.ID.Equals(activeSysID)), Faction.Id);
                     StarSystemStates[activeSysID] = newSys;
                 }
@@ -441,7 +494,7 @@ namespace Pulsar4X.Client
 
         internal void EnableGameMaster()
         {
-            if(Game == null) throw new NullReferenceException("Game is null");
+            if (Game == null) throw new NullReferenceException("Game is null");
             SMenabled = true;
             // Store the current system ID before switching to GameMaster
             _previousSystemIdBeforeSM = SelectedStarSystemId;
@@ -450,16 +503,16 @@ namespace Pulsar4X.Client
 
         internal void DisableGameMaster()
         {
-            if(PlayerFaction == null) throw new NullReferenceException("PlayerFaction is null");
+            if (PlayerFaction == null) throw new NullReferenceException("PlayerFaction is null");
             SMenabled = false;
             SetFaction(PlayerFaction);
 
             // Restore the previous system if the player has access to it
-            if(!string.IsNullOrEmpty(_previousSystemIdBeforeSM) && StarSystemStates.ContainsKey(_previousSystemIdBeforeSM))
+            if (!string.IsNullOrEmpty(_previousSystemIdBeforeSM) && StarSystemStates.ContainsKey(_previousSystemIdBeforeSM))
             {
                 SetActiveSystem(_previousSystemIdBeforeSM);
             }
-            else if(StarSystemStates.Count > 0)
+            else if (StarSystemStates.Count > 0)
             {
                 // If the previous system is not available, switch to the first known system
                 SetActiveSystem(StarSystemStates.Keys.First());
@@ -469,7 +522,7 @@ namespace Pulsar4X.Client
         internal void ToggleGameMaster()
         {
             SMenabled = !SMenabled;
-            if(SMenabled)
+            if (SMenabled)
                 EnableGameMaster();
             else
                 DisableGameMaster();
@@ -755,7 +808,7 @@ namespace Pulsar4X.Client
 
         internal void EntityClicked(int entityGuid, string starSys, MouseButtons button)
         {
-            if(SelectedSysMapRender == null) throw new NullReferenceException("SelectedSysMapRender is null");
+            if (SelectedSysMapRender == null) throw new NullReferenceException("SelectedSysMapRender is null");
 
             var entityState = StarSystemStates[starSys].EntityStatesWithNames[entityGuid];
             LastClickedEntity = entityState;
@@ -763,7 +816,7 @@ namespace Pulsar4X.Client
             ActiveWindow?.EntityClicked(entityState, button);
 
             SelectedSysMapRender.SelectedEntityExtras = new List<IDrawData>();
-            if(LastClickedEntity.DebugOrbitOrder != null)
+            if (LastClickedEntity.DebugOrbitOrder != null)
             {
                 SelectedSysMapRender.SelectedEntityExtras.Add(LastClickedEntity.DebugOrbitOrder);
             }
@@ -774,24 +827,24 @@ namespace Pulsar4X.Client
                 SelectedSysMapRender.SelectedEntityExtras.Add(nodeDraw);
             }
 
-            if(ActiveWindow == null || ActiveWindow.GetActive() == false || ActiveWindow.ClickedEntityIsPrimary)
+            if (ActiveWindow == null || ActiveWindow.GetActive() == false || ActiveWindow.ClickedEntityIsPrimary)
                 PrimaryEntity = LastClickedEntity;
 
             EntityClickedEvent?.Invoke(LastClickedEntity, button);
 
-            if(button == MouseButtons.Primary)
+            if (button == MouseButtons.Primary)
             {
-                if(!EntityWindows.ContainsKey(entityGuid))
+                if (!EntityWindows.ContainsKey(entityGuid))
                 {
                     EntityWindows.Add(entityGuid, new EntityWindow(entityState));
                 }
                 EntityWindows[entityGuid].ToggleActive();
 
-                if(!ViewPort.IsCtrlPressed)
+                if (!ViewPort.IsCtrlPressed)
                 {
-                    foreach(var (id, window) in EntityWindows)
+                    foreach (var (id, window) in EntityWindows)
                     {
-                        if(id == entityGuid) continue;
+                        if (id == entityGuid) continue;
 
                         window.SetActive(false);
                     }
@@ -801,7 +854,7 @@ namespace Pulsar4X.Client
 
         internal void EntityClicked(EntityState entityState, MouseButtons button)
         {
-            if(entityState.StarSystemId == null) throw new NullReferenceException("StarSystemId is null");
+            if (entityState.StarSystemId == null) throw new NullReferenceException("StarSystemId is null");
             EntityClicked(entityState.Id, entityState.StarSystemId, button);
         }
     }

--- a/Pulsar4X/Pulsar4X.Client/State/GlobalUIState.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/GlobalUIState.cs
@@ -357,20 +357,20 @@ namespace Pulsar4X.Client
         {
             if(Game == null || Faction == null) throw new NullReferenceException("Game or Faction is null");
 
+            if (message.SystemId is null)
+                return;
+
             await Task.Run(() => {
-                if(message.SystemId != null)
-                {
-                    if(!StarSystemStates.ContainsKey(message.SystemId)){
-                        var system = Game.Systems.FirstOrDefault(s => s.ID.Equals(message.SystemId));
-                        if(system == null)
-                        {
-                            Console.WriteLine($"ERROR: {message.SystemId} was revealed but not found in the game systems.");
-                            return;
-                        }
-                        StarSystemStates[message.SystemId] = new SystemState(system, Faction.Id);
+                if(!StarSystemStates.ContainsKey(message.SystemId)){
+                    var system = Game.Systems.FirstOrDefault(s => s.ID.Equals(message.SystemId));
+                    if(system == null)
+                    {
+                        Console.WriteLine($"ERROR: {message.SystemId} was revealed but not found in the game systems.");
+                        return;
                     }
-                    OnStarSystemAdded?.Invoke(this, message.SystemId);
+                    StarSystemStates[message.SystemId] = new SystemState(system, Faction.Id);
                 }
+                OnStarSystemAdded?.Invoke(this, message.SystemId);
             });
         }
 

--- a/Pulsar4X/Pulsar4X.Client/State/SystemState.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/SystemState.cs
@@ -40,7 +40,7 @@ namespace Pulsar4X.Client
         }
 
         // Double buffering the changes to avoid locks during events.
-        private ChangeBuffer _clientSide = new();
+        private ChangeBuffer _clientSide = new(); // Should only be read/written to by the UI thread.
         private ChangeBuffer _serverSide = new();
 
         // public List<Message> SystemChanges = new List<Message>();
@@ -148,6 +148,8 @@ namespace Pulsar4X.Client
         public void PreFrameSetup()
         {
             // Atomically swap the buffers.
+            // NOTE: Only _serverSide is atomically read/written.
+            //   _clientSide is not atomically written to, but should be fine since it should only be accessed through the UI thread.
             _clientSide = Interlocked.Exchange(ref _serverSide, _clientSide);
 
             // Deal with additions

--- a/Pulsar4X/Pulsar4X.Client/State/SystemState.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/SystemState.cs
@@ -162,7 +162,10 @@ namespace Pulsar4X.Client
             return Task.CompletedTask;
         }
 
-        public void PreFrameSetup()
+        /// <summary>
+        /// Called every frame.
+        /// </summary>
+        public void Update()
         {
             lock (_bufferSwapLock)
             {

--- a/Pulsar4X/Pulsar4X.Client/State/SystemState.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/SystemState.cs
@@ -42,6 +42,7 @@ namespace Pulsar4X.Client
         // Double buffering the changes to minimize critical section during events.
         private ChangeBuffer _clientSide = new();
         private ChangeBuffer _serverSide = new();
+        private readonly object _bufferSwapLock = new();
 
         // public List<Message> SystemChanges = new List<Message>();
 
@@ -73,8 +74,6 @@ namespace Pulsar4X.Client
         public IReadOnlyDictionary<int, EntityState> EntityStatesColonies => _entitiesWithColonies;
         
         public CameraState? SavedCameraState = null;
-
-        public readonly object Lock = new object();
 
         public SystemState(StarSystem system, int factionId)
         {
@@ -127,7 +126,7 @@ namespace Pulsar4X.Client
         {
             if(message.EntityId == null) return Task.CompletedTask;
 
-            lock(Lock)
+            lock (_bufferSwapLock)
             {
                 _serverSide.EntitiesToAdd.Enqueue(message.EntityId.Value);
             }
@@ -138,7 +137,7 @@ namespace Pulsar4X.Client
         {
             if(message.EntityId == null) return Task.CompletedTask;
 
-            lock(Lock)
+            lock (_bufferSwapLock)
             { 
                 _serverSide.EntitiesToBin.Enqueue(message.EntityId.Value);
             }
@@ -149,7 +148,7 @@ namespace Pulsar4X.Client
         {
             if(message.EntityId == null) return Task.CompletedTask;
 
-            lock(Lock)
+            lock (_bufferSwapLock)
             {
                 _serverSide.EntitiesToUpdate.Enqueue((message.EntityId.Value, message));
             }
@@ -158,7 +157,7 @@ namespace Pulsar4X.Client
 
         public void PreFrameSetup()
         {
-            lock(Lock)
+            lock (_bufferSwapLock)
             {
                 var temp = _serverSide;
                 _serverSide = _clientSide;

--- a/Pulsar4X/Pulsar4X.Client/State/SystemState.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/SystemState.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using Pulsar4X.Colonies;
 using Pulsar4X.Names;
 using Pulsar4X.Movement;
+using System.Threading;
 
 namespace Pulsar4X.Client
 {
@@ -30,9 +31,18 @@ namespace Pulsar4X.Client
         internal SystemSensorContacts? SystemContacts;
         ConcurrentQueue<Message> _sensorChanges = new ConcurrentQueue<Message>();
         internal List<Message> SensorChanges = new List<Message>();
-        public ConcurrentQueue<int> EntitiesToAdd = new();
-        public ConcurrentQueue<(int, Message)> EntitiesToUpdate = new();
-        public SafeList<int> EntitiesToBin = new();
+
+        private class ChangeBuffer
+        {
+            public ConcurrentQueue<int> EntitiesToAdd = new();
+            public ConcurrentQueue<(int, Message)> EntitiesToUpdate = new();
+            public ConcurrentQueue<int> EntitiesToBin = new();
+        }
+
+        // Double buffering the changes to avoid locks during events.
+        private ChangeBuffer _clientSide = new();
+        private ChangeBuffer _serverSide = new();
+
         public List<Message> SystemChanges = new List<Message>();
 
         // Backing fields for the entity dictionaries.
@@ -115,67 +125,62 @@ namespace Pulsar4X.Client
 
         Task OnEntityAddedMessage(Message message)
         {
-            lock(Lock)
-            {
-                if(message.EntityId == null) return Task.CompletedTask;
-                EntitiesToAdd.Enqueue(message.EntityId.Value);
-                return Task.CompletedTask;
-            }
+            if(message.EntityId == null) return Task.CompletedTask;
+
+            _serverSide.EntitiesToAdd.Enqueue(message.EntityId.Value);
+            return Task.CompletedTask;
         }
 
         Task OnEntityRemovedMessage(Message message)
         {
-            lock(Lock)
-            {
-                if(message.EntityId == null) return Task.CompletedTask;
-                if(!EntitiesToBin.Contains(message.EntityId.Value))
-                    EntitiesToBin.Add(message.EntityId.Value);
+            if(message.EntityId == null) return Task.CompletedTask;
 
-                return Task.CompletedTask;
-            }
+            _serverSide.EntitiesToBin.Enqueue(message.EntityId.Value);
+            return Task.CompletedTask;
         }
 
         Task OnEntityUpdatedMessage(Message message)
         {
             if(message.EntityId == null) return Task.CompletedTask;
-            EntitiesToUpdate.Enqueue((message.EntityId.Value, message));
+
+            _serverSide.EntitiesToUpdate.Enqueue((message.EntityId.Value, message));
             return Task.CompletedTask;
         }
 
         public void PreFrameSetup()
         {
-            lock(Lock)
-            {
-                // Deal with additions
-                while(EntitiesToAdd.TryDequeue(out var entityToAdd))
-                {
-                    // FIXME: need to remove the call to the game engine internals
-                    if(StarSystem.TryGetEntityById(entityToAdd, out var entity))
-                    {
-                        SetupEntity(entity, entity.FactionOwnerID);
-                        OnEntityAdded?.Invoke(this, entity);
-                    }
-                }
+            // Atomically swap the buffers.
+            _clientSide = Interlocked.Exchange(ref _serverSide, _clientSide);
 
-                // Deal with removals
-                foreach (var entityToRemove in EntitiesToBin)
+            // Deal with additions
+            while(_clientSide.EntitiesToAdd.TryDequeue(out var entityToAdd))
+            {
+                // FIXME: need to remove the call to the game engine internals
+                if(StarSystem.TryGetEntityById(entityToAdd, out var entity))
                 {
-                    if(_allEntities.TryGetValue(entityToRemove, out var entityState))
-                    {
-                        entityState.Unsubscribe();
-                    }
-                    _allEntities.Remove(entityToRemove);
-                    _entitiesWithPosition.Remove(entityToRemove);
-                    _entitiesWithNames.Remove(entityToRemove);
-                    _entitiesWithColonies.Remove(entityToRemove);
-                    OnEntityRemoved?.Invoke(this, entityToRemove);
+                    SetupEntity(entity, entity.FactionOwnerID);
+                    OnEntityAdded?.Invoke(this, entity);
                 }
-                EntitiesToBin.Clear();
-                SensorChanges.Clear();
-                SystemChanges.Clear();
             }
 
-            while(EntitiesToUpdate.TryDequeue(out var entityToUpdate))
+            // Deal with removals
+            foreach (var entityToRemove in _clientSide.EntitiesToBin)
+            {
+                if(_allEntities.TryGetValue(entityToRemove, out var entityState))
+                {
+                    entityState.Unsubscribe();
+                }
+                _allEntities.Remove(entityToRemove);
+                _entitiesWithPosition.Remove(entityToRemove);
+                _entitiesWithNames.Remove(entityToRemove);
+                _entitiesWithColonies.Remove(entityToRemove);
+                OnEntityRemoved?.Invoke(this, entityToRemove);
+            }
+            _clientSide.EntitiesToBin.Clear();
+            SensorChanges.Clear();
+            SystemChanges.Clear();
+
+            while(_clientSide.EntitiesToUpdate.TryDequeue(out var entityToUpdate))
             {
                 OnEntityUpdated?.Invoke(this, entityToUpdate.Item1, entityToUpdate.Item2);
             }

--- a/Pulsar4X/Pulsar4X.Client/State/SystemState.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/SystemState.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using Pulsar4X.Colonies;
 using Pulsar4X.Names;
 using Pulsar4X.Movement;
-using System.Threading;
 
 namespace Pulsar4X.Client
 {
@@ -75,12 +74,12 @@ namespace Pulsar4X.Client
         /// A snapshot of all entities with a position component in the system that the faction is currently aware of for the current frame.
         /// </summary>
         public IReadOnlyDictionary<int, EntityState> EntityStatesWithPosition => _entitiesWithPosition;
-        
+
         /// <summary>
         /// A snapshot of all entities with a colony component in the system that the faction is currently aware of for the current frame.
         /// </summary>
         public IReadOnlyDictionary<int, EntityState> EntityStatesColonies => _entitiesWithColonies;
-        
+
         public CameraState? SavedCameraState = null;
 
         public SystemState(StarSystem system, int factionId)
@@ -146,7 +145,7 @@ namespace Pulsar4X.Client
             if(message.EntityId == null) return Task.CompletedTask;
 
             lock (_bufferSwapLock)
-            { 
+            {
                 _serverSide.EntitiesToBin.Enqueue(message.EntityId.Value);
             }
             return Task.CompletedTask;

--- a/Pulsar4X/Pulsar4X.Client/State/SystemState.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/SystemState.cs
@@ -30,14 +30,38 @@ namespace Pulsar4X.Client
         internal SystemSensorContacts? SystemContacts;
         ConcurrentQueue<Message> _sensorChanges = new ConcurrentQueue<Message>();
         internal List<Message> SensorChanges = new List<Message>();
-        public ConcurrentQueue<int> EntitiesToAdd = new ();
-        public ConcurrentQueue<(int, Message)> EntitiesToUpdate = new ();
-        public SafeList<int> EntitiesToBin = new ();
+        public ConcurrentQueue<int> EntitiesToAdd = new();
+        public ConcurrentQueue<(int, Message)> EntitiesToUpdate = new();
+        public SafeList<int> EntitiesToBin = new();
         public List<Message> SystemChanges = new List<Message>();
-        public SafeDictionary<int, EntityState> AllEntities = new ();
-        public SafeDictionary<int, EntityState> EntityStatesWithNames = new ();
-        public SafeDictionary<int, EntityState> EntityStatesWithPosition = new ();
-        public SafeDictionary<int, EntityState> EntityStatesColonies = new ();
+
+        // Backing fields for the entity dictionaries.
+        // Updated in PreFrameSetup based on queued changes.
+        private Dictionary<int, EntityState> _allEntities = [];
+        private Dictionary<int, EntityState> _entitiesWithNames = [];
+        private Dictionary<int, EntityState> _entitiesWithPosition = [];
+        private Dictionary<int, EntityState> _entitiesWithColonies = [];
+
+        /// <summary>
+        /// A snapshot of all entities in the system that the faction is currently aware of for the current frame.
+        /// </summary>
+        public IReadOnlyDictionary<int, EntityState> AllEntities => _allEntities;
+
+        /// <summary>
+        /// A snapshot of all entities with a name component in the system that the faction is currently aware of for the current frame.
+        /// </summary>
+        public IReadOnlyDictionary<int, EntityState> EntityStatesWithNames => _entitiesWithNames;
+
+        /// <summary>
+        /// A snapshot of all entities with a position component in the system that the faction is currently aware of for the current frame.
+        /// </summary>
+        public IReadOnlyDictionary<int, EntityState> EntityStatesWithPosition => _entitiesWithPosition;
+        
+        /// <summary>
+        /// A snapshot of all entities with a colony component in the system that the faction is currently aware of for the current frame.
+        /// </summary>
+        public IReadOnlyDictionary<int, EntityState> EntityStatesColonies => _entitiesWithColonies;
+        
         public CameraState? SavedCameraState = null;
 
         public readonly object Lock = new object();
@@ -70,22 +94,22 @@ namespace Pulsar4X.Client
         {
             var entityState = new EntityState(entity, entity.Id, factionId);
 
-            if(!AllEntities.ContainsKey(entity.Id))
-                AllEntities.Add(entity.Id, entityState);
+            if(!_allEntities.ContainsKey(entity.Id))
+                _allEntities.Add(entity.Id, entityState);
 
             if (!EntityStatesWithNames.ContainsKey(entity.Id) && entity.TryGetDataBlob<NameDB>(out var nameDB))
             {
                 entityState.Name = nameDB.GetName(factionId); // TODO: doesn't update when if/when the entity is renamed
-                EntityStatesWithNames.Add(entity.Id, entityState);
+                _entitiesWithNames.Add(entity.Id, entityState);
             }
             if (!EntityStatesWithPosition.ContainsKey(entity.Id) && entity.TryGetDataBlob<PositionDB>(out var positionDB))
             {
                 entityState.Position = positionDB;
-                EntityStatesWithPosition.Add(entity.Id, entityState);
+                _entitiesWithPosition.Add(entity.Id, entityState);
             }
             if (!EntityStatesColonies.ContainsKey(entity.Id) && entity.HasDataBlob<ColonyInfoDB>())
             {
-                EntityStatesColonies.Add(entity.Id, entityState);
+                _entitiesWithColonies.Add(entity.Id, entityState);
             }
         }
 
@@ -136,14 +160,14 @@ namespace Pulsar4X.Client
                 // Deal with removals
                 foreach (var entityToRemove in EntitiesToBin)
                 {
-                    if(AllEntities.TryGetValue(entityToRemove, out var entityState))
+                    if(_allEntities.TryGetValue(entityToRemove, out var entityState))
                     {
                         entityState.Unsubscribe();
                     }
-                    AllEntities.Remove(entityToRemove);
-                    EntityStatesWithPosition.Remove(entityToRemove);
-                    EntityStatesWithNames.Remove(entityToRemove);
-                    EntityStatesColonies.Remove(entityToRemove);
+                    _allEntities.Remove(entityToRemove);
+                    _entitiesWithPosition.Remove(entityToRemove);
+                    _entitiesWithNames.Remove(entityToRemove);
+                    _entitiesWithColonies.Remove(entityToRemove);
                     OnEntityRemoved?.Invoke(this, entityToRemove);
                 }
                 EntitiesToBin.Clear();

--- a/Pulsar4X/Pulsar4X.Client/State/SystemState.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/SystemState.cs
@@ -29,8 +29,8 @@ namespace Pulsar4X.Client
         private int _factionId;
         internal StarSystem StarSystem;
         internal SystemSensorContacts? SystemContacts;
-        ConcurrentQueue<Message> _sensorChanges = new ConcurrentQueue<Message>();
-        internal List<Message> SensorChanges = new List<Message>();
+        // ConcurrentQueue<Message> _sensorChanges = new ConcurrentQueue<Message>();
+        // internal List<Message> SensorChanges = new List<Message>();
 
         private class ChangeBuffer
         {
@@ -43,7 +43,7 @@ namespace Pulsar4X.Client
         private ChangeBuffer _clientSide = new();
         private ChangeBuffer _serverSide = new();
 
-        public List<Message> SystemChanges = new List<Message>();
+        // public List<Message> SystemChanges = new List<Message>();
 
         // Backing fields for the entity dictionaries.
         // Updated in PreFrameSetup based on queued changes.
@@ -80,8 +80,8 @@ namespace Pulsar4X.Client
         {
             StarSystem = system;
             StarSystem.SetupDefaultNeutralEntitiesForFaction(factionId);
-            SystemContacts = system.GetSensorContacts(factionId);
-            _sensorChanges = SystemContacts.Changes.Subscribe();
+            // SystemContacts = system.GetSensorContacts(factionId);
+            // _sensorChanges = SystemContacts.Changes.Subscribe();
             _factionId = factionId;
 
             var entities = StarSystem.GetFilteredEntities(EntityFilter.Friendly | EntityFilter.Neutral | EntityFilter.Hostile, factionId);
@@ -177,8 +177,8 @@ namespace Pulsar4X.Client
                 OnEntityRemoved?.Invoke(this, entityToRemove);
             }
             _clientSide.EntitiesToBin.Clear();
-            SensorChanges.Clear();
-            SystemChanges.Clear();
+            // SensorChanges.Clear();
+            // SystemChanges.Clear();
 
             while(_clientSide.EntitiesToUpdate.TryDequeue(out var entityToUpdate))
             {

--- a/Pulsar4X/Pulsar4X.Client/State/SystemState.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/SystemState.cs
@@ -91,7 +91,7 @@ namespace Pulsar4X.Client
             _factionId = factionId;
 
             var entities = StarSystem.GetFilteredEntities(EntityFilter.Friendly | EntityFilter.Neutral | EntityFilter.Hostile, factionId);
-            foreach(var entity in entities)
+            foreach (var entity in entities)
             {
                 SetupEntity(entity, entity.FactionOwnerID);
             }
@@ -110,7 +110,7 @@ namespace Pulsar4X.Client
         {
             var entityState = new EntityState(entity, entity.Id, factionId);
 
-            if(!_allEntities.ContainsKey(entity.Id))
+            if (!_allEntities.ContainsKey(entity.Id))
                 _allEntities.Add(entity.Id, entityState);
 
             if (!EntityStatesWithNames.ContainsKey(entity.Id) && entity.TryGetDataBlob<NameDB>(out var nameDB))
@@ -131,7 +131,7 @@ namespace Pulsar4X.Client
 
         Task OnEntityAddedMessage(Message message)
         {
-            if(message.EntityId == null) return Task.CompletedTask;
+            if (message.EntityId == null) return Task.CompletedTask;
 
             lock (_bufferSwapLock)
             {
@@ -142,7 +142,7 @@ namespace Pulsar4X.Client
 
         Task OnEntityRemovedMessage(Message message)
         {
-            if(message.EntityId == null) return Task.CompletedTask;
+            if (message.EntityId == null) return Task.CompletedTask;
 
             lock (_bufferSwapLock)
             {
@@ -153,7 +153,7 @@ namespace Pulsar4X.Client
 
         Task OnEntityUpdatedMessage(Message message)
         {
-            if(message.EntityId == null) return Task.CompletedTask;
+            if (message.EntityId == null) return Task.CompletedTask;
 
             lock (_bufferSwapLock)
             {
@@ -172,20 +172,27 @@ namespace Pulsar4X.Client
             }
 
             // Deal with additions
-            while(_clientSide.EntitiesToAdd.TryDequeue(out var entityToAdd))
+            while (_clientSide.EntitiesToAdd.TryDequeue(out var entityToAdd))
             {
                 // FIXME: need to remove the call to the game engine internals
-                if(StarSystem.TryGetEntityById(entityToAdd, out var entity))
+                if (StarSystem.TryGetEntityById(entityToAdd, out var entity))
                 {
                     SetupEntity(entity, entity.FactionOwnerID);
                     OnEntityAdded?.Invoke(this, entity);
                 }
             }
 
-            // Deal with removals
-            while(_clientSide.EntitiesToBin.TryDequeue(out var entityToRemove))
+            // Run entity update before entity removals to ensure they process.
+            // Possibly not strictly necessary, but seems safer for now.
+            foreach (var entity in _allEntities.Values)
             {
-                if(_allEntities.TryGetValue(entityToRemove, out var entityState))
+                entity.Update();
+            }
+
+            // Deal with removals
+            while (_clientSide.EntitiesToBin.TryDequeue(out var entityToRemove))
+            {
+                if (_allEntities.TryGetValue(entityToRemove, out var entityState))
                 {
                     entityState.Unsubscribe();
                 }
@@ -198,7 +205,7 @@ namespace Pulsar4X.Client
             // SensorChanges.Clear();
             // SystemChanges.Clear();
 
-            while(_clientSide.EntitiesToUpdate.TryDequeue(out var entityToUpdate))
+            while (_clientSide.EntitiesToUpdate.TryDequeue(out var entityToUpdate))
             {
                 OnEntityUpdated?.Invoke(this, entityToUpdate.Item1, entityToUpdate.Item2);
             }
@@ -239,7 +246,7 @@ namespace Pulsar4X.Client
 
         public EntityState? GetEntityById(int id)
         {
-            if(!AllEntities.ContainsKey(id))
+            if (!AllEntities.ContainsKey(id))
                 return null;
 
             return AllEntities[id];

--- a/Pulsar4X/Pulsar4X.Client/State/SystemState.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/SystemState.cs
@@ -39,8 +39,8 @@ namespace Pulsar4X.Client
             public ConcurrentQueue<int> EntitiesToBin = new();
         }
 
-        // Double buffering the changes to avoid locks during events.
-        private ChangeBuffer _clientSide = new(); // Should only be read/written to by the UI thread.
+        // Double buffering the changes to minimize critical section during events.
+        private ChangeBuffer _clientSide = new();
         private ChangeBuffer _serverSide = new();
 
         // public List<Message> SystemChanges = new List<Message>();
@@ -73,6 +73,8 @@ namespace Pulsar4X.Client
         public IReadOnlyDictionary<int, EntityState> EntityStatesColonies => _entitiesWithColonies;
         
         public CameraState? SavedCameraState = null;
+
+        public readonly object Lock = new object();
 
         public SystemState(StarSystem system, int factionId)
         {
@@ -125,7 +127,10 @@ namespace Pulsar4X.Client
         {
             if(message.EntityId == null) return Task.CompletedTask;
 
-            _serverSide.EntitiesToAdd.Enqueue(message.EntityId.Value);
+            lock(Lock)
+            {
+                _serverSide.EntitiesToAdd.Enqueue(message.EntityId.Value);
+            }
             return Task.CompletedTask;
         }
 
@@ -133,7 +138,10 @@ namespace Pulsar4X.Client
         {
             if(message.EntityId == null) return Task.CompletedTask;
 
-            _serverSide.EntitiesToBin.Enqueue(message.EntityId.Value);
+            lock(Lock)
+            { 
+                _serverSide.EntitiesToBin.Enqueue(message.EntityId.Value);
+            }
             return Task.CompletedTask;
         }
 
@@ -141,16 +149,21 @@ namespace Pulsar4X.Client
         {
             if(message.EntityId == null) return Task.CompletedTask;
 
-            _serverSide.EntitiesToUpdate.Enqueue((message.EntityId.Value, message));
+            lock(Lock)
+            {
+                _serverSide.EntitiesToUpdate.Enqueue((message.EntityId.Value, message));
+            }
             return Task.CompletedTask;
         }
 
         public void PreFrameSetup()
         {
-            // Atomically swap the buffers.
-            // NOTE: Only _serverSide is atomically read/written.
-            //   _clientSide is not atomically written to, but should be fine since it should only be accessed through the UI thread.
-            _clientSide = Interlocked.Exchange(ref _serverSide, _clientSide);
+            lock(Lock)
+            {
+                var temp = _serverSide;
+                _serverSide = _clientSide;
+                _clientSide = temp;
+            }
 
             // Deal with additions
             while(_clientSide.EntitiesToAdd.TryDequeue(out var entityToAdd))

--- a/Pulsar4X/Pulsar4X.Client/State/SystemState.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/SystemState.cs
@@ -27,8 +27,16 @@ namespace Pulsar4X.Client
         public event SystemStateEntityUpdateHandler? OnEntityUpdated;
 
         private int _factionId;
-        internal StarSystem StarSystem;
-        internal SystemSensorContacts? SystemContacts;
+
+        /// <summary>
+        /// The actual star system that SystemState proxies.
+        /// </summary>
+        /// <remarks>
+        /// Prefer using native SystemState methods instead of directly accessing the StarSystem.
+        /// </remarks>
+        internal StarSystem StarSystem { get; private set; }
+
+        internal SystemSensorContacts? SystemContacts { get; private set; }
         // ConcurrentQueue<Message> _sensorChanges = new ConcurrentQueue<Message>();
         // internal List<Message> SensorChanges = new List<Message>();
 

--- a/Pulsar4X/Pulsar4X.Client/State/SystemState.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/SystemState.cs
@@ -164,7 +164,7 @@ namespace Pulsar4X.Client
             }
 
             // Deal with removals
-            foreach (var entityToRemove in _clientSide.EntitiesToBin)
+            while(_clientSide.EntitiesToBin.TryDequeue(out var entityToRemove))
             {
                 if(_allEntities.TryGetValue(entityToRemove, out var entityState))
                 {
@@ -176,7 +176,6 @@ namespace Pulsar4X.Client
                 _entitiesWithColonies.Remove(entityToRemove);
                 OnEntityRemoved?.Invoke(this, entityToRemove);
             }
-            _clientSide.EntitiesToBin.Clear();
             // SensorChanges.Clear();
             // SystemChanges.Clear();
 

--- a/Pulsar4X/Pulsar4X.Client/State/SystemState.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/SystemState.cs
@@ -78,7 +78,7 @@ namespace Pulsar4X.Client
         {
             StarSystem = system;
             StarSystem.SetupDefaultNeutralEntitiesForFaction(factionId);
-            // SystemContacts = system.GetSensorContacts(factionId);
+            SystemContacts = system.GetSensorContacts(factionId);
             // _sensorChanges = SystemContacts.Changes.Subscribe();
             _factionId = factionId;
 

--- a/Pulsar4X/Pulsar4X.Client/State/SystemState.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/SystemState.cs
@@ -74,8 +74,6 @@ namespace Pulsar4X.Client
         
         public CameraState? SavedCameraState = null;
 
-        public readonly object Lock = new object();
-
         public SystemState(StarSystem system, int factionId)
         {
             StarSystem = system;


### PR DESCRIPTION
The PR aims to cleanup the system state and reduce the amount of locking required during `SystemState` updates from both the engine and client sides. It achieves this through double buffering.

## Double buffered update

Extended the event queue to include a double buffering mechanism by having a second event triplet (`ToAdd`, `ToRemove`, `ToUpdate`). The two triplets are designated as `serverSide` and `clientSide`.

The update works on the following rules:
- All events that are produced by the game engine are recorded in the `serverSide` queue.
- On each call to `PreFrameUpdate` the references to `serverSide` and `clientSide` are swapped.

This change allows the critical section around the `PreFrameUpdate` to be reduced to just the swap.

### Event queues
The event queues themselves are all changed to `ConcurrentQueue<T>` which is lock-free. The notable change is that `ToRemove` does not check for duplicate `toRemove` ids inside it when enqueueing an event to allow the event handlers to have minimal contention. The deduplication functionality can be reimplemented inside `PreFrameUpdate` if it is required.


## API cleanup

### Entity dictionaries

The following dictionaries have been converted to full properties:
- `AllEntities`
- `EntityStatesWithNames`
- `EntityStatesWithPosition`
- `EntityStatesColonies`

The external type has been changed to `IReadOnlyDictionary` as they should not be modified outside of `PreFrameUpdate`.
The internal backing fields have been changed from `SafeDictionary` to `Dictionary` as all modifications should happen on the UI thread in `PreFrameUpdate`.

### Privatized variables
- `Lock` object has been changed to `private` visibility.

### Autoprop
The following fields have been converted to auto properties to restrict possible external changes:
- `SystemState`
- `SystemContacts`

### Cleanup of unused variables
Variables that do not appear to have a clear use, due to no external references and no internal use, have been commented out.
- `_sensorChanges` is subscribed to, but never read.
- `SensorChanges` is only cleared in `PreFrameUpdate`.
- `SystemChanges` is only cleared in `PreFrameUpdate`.