### PR TITLE
Remove dependency on `NUnit` in the core engine.

### DIFF
--- a/Pulsar4X/GameEngine/Engine/Datablobs/TreeHierarchyDB.cs
+++ b/Pulsar4X/GameEngine/Engine/Datablobs/TreeHierarchyDB.cs
@@ -1,5 +1,4 @@
 using Newtonsoft.Json;
-using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -207,6 +206,7 @@ namespace Pulsar4X.Datablobs
         }
 
         /*
+        // Requires NUnit.Framework. Possibly move to tests project?
         [TestFixture]
         [Description("TreeHierarchyDB Tests")]
         internal class TreeHierarchyTests

--- a/Pulsar4X/GameEngine/GameEngine.csproj
+++ b/Pulsar4X/GameEngine/GameEngine.csproj
@@ -13,7 +13,6 @@
   <ItemGroup>
     <PackageReference Include="CoreCLR-NCalc" Version="2.2.113" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Pulsar4X.OrbitalMath\Pulsar4X.Orbital.csproj" />

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/Debug/DebugWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/Debug/DebugWindow.cs
@@ -20,7 +20,6 @@ using Pulsar4X.Galaxy;
 using Pulsar4X.Movement;
 using Pulsar4X.Storage;
 using SDL3;
-using NUnit.Framework;
 
 namespace Pulsar4X.Client
 {

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/OrderCreationWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/OrderCreationWindow.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using ImGuiNET;
-using NUnit.Framework;
 using Pulsar4X.Client.Interface.Widgets;
 using Pulsar4X.Datablobs;
 using Pulsar4X.Engine;


### PR DESCRIPTION
The core engine does not utilize `NUnit` and the only reference is a commented out test fixture. References to `NUnit` in the client code have also been removed as they weren't used.