### PR TITLE
Change `StarSystem` to decide its `ActivityState` internally.

### DIFF
--- a/Pulsar4X/GameEngine/Engine/Entities/EntityManager.cs
+++ b/Pulsar4X/GameEngine/Engine/Entities/EntityManager.cs
@@ -247,9 +247,9 @@ namespace Pulsar4X.Engine
 
             AddEntity(entity, dataBlobs);
 
-            if (this is StarSystem starSystem && starSystem.ActivityState == SystemActivityState.Stasis)
+            if (this is StarSystem starSystem)
             {
-                starSystem.SetActivityState(SystemActivityState.Background);
+                starSystem.UpdateActivityState();
             }
         }
 
@@ -338,10 +338,9 @@ namespace Pulsar4X.Engine
             }
             _entitiesTaggedForRemoval.Clear();
 
-            if (this is StarSystem starSys && starSys.ActivityState != SystemActivityState.Stasis)
+            if (this is StarSystem starSys)
             {
-                if (!HasFactionEntities())
-                    starSys.SetActivityState(SystemActivityState.Stasis);
+                starSys.UpdateActivityState();
             }
         }
 

--- a/Pulsar4X/GameEngine/Engine/Entities/StarSystem.cs
+++ b/Pulsar4X/GameEngine/Engine/Entities/StarSystem.cs
@@ -24,7 +24,7 @@ namespace Pulsar4X.Engine
         [JsonIgnore]
         public SystemActivityState ActivityState { get; private set; } = SystemActivityState.Stasis;
 
-        // TODO: Find better name for this.
+        // TODO: Find better names for this.
         /// <summary>
         /// Number of external observers (e.g. clients) currently observing this system.
         /// 

--- a/Pulsar4X/GameEngine/Engine/Entities/StarSystem.cs
+++ b/Pulsar4X/GameEngine/Engine/Entities/StarSystem.cs
@@ -32,12 +32,32 @@ namespace Pulsar4X.Engine
         [JsonProperty]
         public SystemActivityState ActivityState { get; set; } = SystemActivityState.Stasis;
 
+        /// <summary>
+        /// Number of external observers (e.g. clients) currently observing this system.
+        /// 
+        /// If this value is greater than 0, the system needs to be simulated in at least <see cref="SystemActivityState.Background"/> mode.
+        /// </summary>
+        [JsonIgnore]
+        private int _externalObservers = 0;
+
+        /// <summary>
+        /// Number of external observers (e.g. clients) currently observing this system with priority.
+        /// 
+        /// If this value is greater than 0, the system needs to be simulated in <see cref="SystemActivityState.Foreground"/> mode.
+        /// </summary>
+        [JsonIgnore]
+        private int _externalPriorityObservers = 0;
+
+        // TODO: Possibly rework this to atomic if it causes perf issues.
+        [JsonIgnore]
+        private readonly object _observerLock = new();
+
         [JsonProperty]
         internal int SystemIndex { get; set; }
 
         [PublicAPI]
         [JsonProperty]
-        public NameDB NameDB { get;  set; }
+        public NameDB NameDB { get; set; }
 
         //[PublicAPI]
         //public EntityManager SystemManager { get { return this; } }
@@ -46,7 +66,7 @@ namespace Pulsar4X.Engine
 
 
 
- 
+
         [JsonConstructor]
         public StarSystem()
         {
@@ -57,8 +77,8 @@ namespace Pulsar4X.Engine
             base.Initialize(game, seed, postLoad);
 
             NameDB = new NameDB(name);
-            
-            if(systemID.IsNotNullOrEmpty())
+
+            if (systemID.IsNotNullOrEmpty())
                 ManagerID = systemID;
 
             game.Systems.Add(this);
@@ -122,6 +142,94 @@ namespace Pulsar4X.Engine
                 case SystemActivityState.Stasis:
                     ManagerSubpulses.FrequencyMultiplier = 1.0;
                     break;
+            }
+        }
+
+        // TODO: Introduce wrappers for these methods.
+        /// <summary>
+        /// Increments the count of external observers monitoring this system.
+        /// 
+        /// If priority is true, this observer requires the system to be in Foreground mode; otherwise, Background mode is sufficient.
+        /// </summary>
+        /// <param name="priority"></param>
+        public void IncrementExternalObserver(bool priority = false)
+        {
+            // TODO: Make thread safe.
+            _externalObservers++;
+
+            if (priority)
+                PromoteExternalObserverInternal(false);
+
+            // TODO: Defer update to the game engine thread.
+            UpdateActivityState();
+        }
+
+        /// <summary>
+        /// Decrements the count of external observers monitoring this system.
+        /// 
+        /// If priority is true, the observer is assumed to have required Foreground mode; otherwise, Background mode is assumed.
+        /// </summary>
+        /// <param name="priority"></param>
+        public void DecrementExternalObserver(bool priority = false)
+        {
+            // TODO: Make thread safe.
+            if (priority)
+                DemoteExternalObserverInternal(false);
+
+            Debug.Assert(_externalObservers > 0, "External observers cannot be negative.");
+            _externalObservers--;
+
+            // TODO: Defer update to the game engine thread.
+            UpdateActivityState();
+        }
+
+        public void PromoteExternalObserver() => PromoteExternalObserverInternal(true);
+
+        public void DemoteExternalObserver() => DemoteExternalObserverInternal(true);
+
+        internal void PromoteExternalObserverInternal(bool doUpdate)
+        {
+            // TODO: Make thread safe.
+            Debug.Assert(_externalPriorityObservers < _externalObservers, "Can not have more priority observers than total observers.");
+            _externalPriorityObservers++;
+            if (doUpdate)
+                UpdateActivityState();
+        }
+
+        internal void DemoteExternalObserverInternal(bool doUpdate)
+        {
+            // TODO: Make thread safe.
+            Debug.Assert(_externalPriorityObservers > 0, "External priority observers cannot be negative.");
+            _externalPriorityObservers--;
+            if(doUpdate)
+                UpdateActivityState();
+        }
+
+        /// <summary>
+        /// Updates the activity state of the system respecting observer rules.
+        /// </summary>
+        internal void UpdateActivityState()
+        {
+            var oldState = ActivityState;
+            var newState = SystemActivityState.Stasis;
+
+            // TODO: Sync.
+            if (_externalPriorityObservers > 0)
+            {
+                newState = SystemActivityState.Foreground;
+            }
+            else if (_externalObservers > 0)
+            {
+                newState = SystemActivityState.Background;
+            }
+            else if (HasFactionEntities())
+            {
+                newState = SystemActivityState.Background;
+            }
+
+            if (oldState != newState)
+            {
+                SetActivityState(newState);
             }
         }
 

--- a/Pulsar4X/GameEngine/Engine/Entities/StarSystem.cs
+++ b/Pulsar4X/GameEngine/Engine/Entities/StarSystem.cs
@@ -29,8 +29,8 @@ namespace Pulsar4X.Engine
             }
         }
 
-        [JsonProperty]
-        public SystemActivityState ActivityState { get; set; } = SystemActivityState.Stasis;
+        [JsonIgnore]
+        public SystemActivityState ActivityState { get; private set; } = SystemActivityState.Stasis;
 
         /// <summary>
         /// Number of external observers (e.g. clients) currently observing this system.

--- a/Pulsar4X/GameEngine/Engine/Entities/StarSystem.cs
+++ b/Pulsar4X/GameEngine/Engine/Entities/StarSystem.cs
@@ -18,20 +18,13 @@ namespace Pulsar4X.Engine
     [JsonObject(MemberSerialization.OptIn)]
     public class StarSystem : EntityManager
     {
-
-
         [PublicAPI]
-        public string ID
-        {
-            get
-            {
-                return ManagerID;
-            }
-        }
+        public string ID => ManagerID;
 
         [JsonIgnore]
         public SystemActivityState ActivityState { get; private set; } = SystemActivityState.Stasis;
 
+        // TODO: Find better name for this.
         /// <summary>
         /// Number of external observers (e.g. clients) currently observing this system.
         /// 
@@ -61,11 +54,6 @@ namespace Pulsar4X.Engine
 
         //[PublicAPI]
         //public EntityManager SystemManager { get { return this; } }
-
-
-
-
-
 
         [JsonConstructor]
         public StarSystem()

--- a/Pulsar4X/GameEngine/Engine/Entities/StarSystem.cs
+++ b/Pulsar4X/GameEngine/Engine/Entities/StarSystem.cs
@@ -121,7 +121,10 @@ namespace Pulsar4X.Engine
 
         // }
 
-        public void SetActivityState(SystemActivityState newState)
+        [Obsolete("Avoid setting the state directly. Use external observers.")]
+        public void SetActivityState(SystemActivityState newState) => SetActivityStateInternal(newState);
+
+        internal void SetActivityStateInternal(SystemActivityState newState)
         {
             var oldState = ActivityState;
             ActivityState = newState;
@@ -229,7 +232,7 @@ namespace Pulsar4X.Engine
 
             if (oldState != newState)
             {
-                SetActivityState(newState);
+                SetActivityStateInternal(newState);
             }
         }
 

--- a/Pulsar4X/GameEngine/Engine/Entities/StarSystem.cs
+++ b/Pulsar4X/GameEngine/Engine/Entities/StarSystem.cs
@@ -145,14 +145,16 @@ namespace Pulsar4X.Engine
         /// <param name="priority"></param>
         public void IncrementExternalObserver(bool priority = false)
         {
-            // TODO: Make thread safe.
-            _externalObservers++;
+            lock (_observerLock)
+            {
+                _externalObservers++;
 
-            if (priority)
-                PromoteExternalObserverInternal(false);
+                if (priority)
+                    PromoteExternalObserverInternal(false);
 
-            // TODO: Defer update to the game engine thread.
-            UpdateActivityState();
+                // TODO: Defer update to the game engine thread.
+                UpdateActivityState();
+            }
         }
 
         /// <summary>
@@ -163,15 +165,17 @@ namespace Pulsar4X.Engine
         /// <param name="priority"></param>
         public void DecrementExternalObserver(bool priority = false)
         {
-            // TODO: Make thread safe.
-            if (priority)
-                DemoteExternalObserverInternal(false);
+            lock (_observerLock)
+            {
+                if (priority)
+                    DemoteExternalObserverInternal(false);
 
-            Debug.Assert(_externalObservers > 0, "External observers cannot be negative.");
-            _externalObservers--;
+                Debug.Assert(_externalObservers > 0, "External observers cannot be negative.");
+                _externalObservers--;
 
-            // TODO: Defer update to the game engine thread.
-            UpdateActivityState();
+                // TODO: Defer update to the game engine thread.
+                UpdateActivityState();
+            }
         }
 
         public void PromoteExternalObserver() => PromoteExternalObserverInternal(true);
@@ -180,20 +184,24 @@ namespace Pulsar4X.Engine
 
         internal void PromoteExternalObserverInternal(bool doUpdate)
         {
-            // TODO: Make thread safe.
-            Debug.Assert(_externalPriorityObservers < _externalObservers, "Can not have more priority observers than total observers.");
-            _externalPriorityObservers++;
-            if (doUpdate)
-                UpdateActivityState();
+            lock (_observerLock)
+            {
+                Debug.Assert(_externalPriorityObservers < _externalObservers, "Can not have more priority observers than total observers.");
+                _externalPriorityObservers++;
+                if (doUpdate)
+                    UpdateActivityState();
+            }
         }
 
         internal void DemoteExternalObserverInternal(bool doUpdate)
         {
-            // TODO: Make thread safe.
-            Debug.Assert(_externalPriorityObservers > 0, "External priority observers cannot be negative.");
-            _externalPriorityObservers--;
-            if(doUpdate)
-                UpdateActivityState();
+            lock (_observerLock)
+            {
+                Debug.Assert(_externalPriorityObservers > 0, "External priority observers cannot be negative.");
+                _externalPriorityObservers--;
+                if (doUpdate)
+                    UpdateActivityState();
+            }
         }
 
         /// <summary>
@@ -204,23 +212,26 @@ namespace Pulsar4X.Engine
             var oldState = ActivityState;
             var newState = SystemActivityState.Stasis;
 
-            // TODO: Sync.
-            if (_externalPriorityObservers > 0)
+            // TODO: Optimize critical sections.
+            lock (_observerLock)
             {
-                newState = SystemActivityState.Foreground;
-            }
-            else if (_externalObservers > 0)
-            {
-                newState = SystemActivityState.Background;
-            }
-            else if (HasFactionEntities())
-            {
-                newState = SystemActivityState.Background;
-            }
+                if (_externalPriorityObservers > 0)
+                {
+                    newState = SystemActivityState.Foreground;
+                }
+                else if (_externalObservers > 0)
+                {
+                    newState = SystemActivityState.Background;
+                }
+                else if (HasFactionEntities())
+                {
+                    newState = SystemActivityState.Background;
+                }
 
-            if (oldState != newState)
-            {
-                SetActivityStateInternal(newState);
+                if (oldState != newState)
+                {
+                    SetActivityStateInternal(newState);
+                }
             }
         }
 

--- a/Pulsar4X/GameEngine/Engine/Game.cs
+++ b/Pulsar4X/GameEngine/Engine/Game.cs
@@ -269,8 +269,7 @@ namespace Pulsar4X.Engine
                 }
 
                 // Systems with faction entities start as Background, others stay Stasis (default)
-                if (system.HasFactionEntities())
-                    system.SetActivityState(SystemActivityState.Background);
+                system.UpdateActivityState();
             }
         }
     }

--- a/Pulsar4X/GameEngine/Movement/InterSystemJumpProcessor.cs
+++ b/Pulsar4X/GameEngine/Movement/InterSystemJumpProcessor.cs
@@ -13,9 +13,6 @@ namespace Pulsar4X.Movement
         }
         internal static void JumpIn(Game game, SystemEntityJumpPair jumpPair)
         {
-            if (jumpPair.JumpSystem.ActivityState == SystemActivityState.Stasis)
-                jumpPair.JumpSystem.SetActivityState(SystemActivityState.Background);
-
             jumpPair.JumpSystem.Transfer(jumpPair.JumpingEntity);
         }
 

--- a/Pulsar4X/Pulsar4X.Client/State/GlobalUIState.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/GlobalUIState.cs
@@ -332,6 +332,12 @@ namespace Pulsar4X.Client
             if(setAsPlayer)
                 PlayerFaction = factionEntity;
 
+            // Remove the old selected system's priority observer
+            if(!string.IsNullOrEmpty(SelectedStarSystemId))
+            {
+                StarSystemStates[SelectedStarSystemId].StarSystem.DecrementExternalObserver(true);
+            }
+
             Faction = factionEntity;
             FactionInfoDB factionInfo = factionEntity.GetDataBlob<FactionInfoDB>();
             StarSystemStates = new SafeDictionary<string, SystemState>();
@@ -339,9 +345,14 @@ namespace Pulsar4X.Client
             {
                 var system = Game.Systems.FirstOrDefault(s => s.ID.Equals(guid));
                 if(system == null) continue;
-                if (system.ActivityState == SystemActivityState.Stasis)
-                    system.SetActivityState(SystemActivityState.Background);
+
                 StarSystemStates[guid] = new SystemState(system, factionEntity.Id);
+
+                // Notify that the currently selected system is on focus.
+                if(!string.IsNullOrEmpty(SelectedStarSystemId) && SelectedStarSystemId.Equals(guid))
+                {
+                    system.IncrementExternalObserver(true);
+                }
             }
 
             // Unsubscribe to any previous message listeners
@@ -383,19 +394,20 @@ namespace Pulsar4X.Client
                 if(!string.IsNullOrEmpty(SelectedStarSystemId) && StarSystemStates.ContainsKey(SelectedStarSystemId))
                 {
                     var oldSystem = StarSystemStates[SelectedStarSystemId].StarSystem;
-                    if (oldSystem.ActivityState == SystemActivityState.Foreground)
-                        oldSystem.SetActivityState(SystemActivityState.Background);
+
+                    oldSystem.DecrementExternalObserver(true);
 
                     StarSystemStates[SelectedStarSystemId].SavedCameraState = Camera.SaveState();
                 }
 
                 if(!StarSystemStates.ContainsKey(activeSysID)){
-                    StarSystemStates[activeSysID] = new SystemState(Game.Systems.First(s => s.ID.Equals(activeSysID)), Faction.Id);
+                    var newSys = new SystemState(Game.Systems.First(s => s.ID.Equals(activeSysID)), Faction.Id);
+                    StarSystemStates[activeSysID] = newSys;
                 }
 
                 // Promote the new system to Foreground
                 var newSystem = Game.Systems.First(s => s.ID.Equals(activeSysID));
-                newSystem.SetActivityState(SystemActivityState.Foreground);
+                newSystem.IncrementExternalObserver(true);
 
                 SelectedStarSystemId = activeSysID;
 

--- a/Pulsar4X/Pulsar4X.Tests/ActivityStateTests.cs
+++ b/Pulsar4X/Pulsar4X.Tests/ActivityStateTests.cs
@@ -122,5 +122,94 @@ namespace Pulsar4X.Tests
             Assert.AreEqual(SystemActivityState.Background, targetSystem.ActivityState,
                 "Target system should be promoted to Background after receiving an entity.");
         }
+
+        [Test]
+        public void ExternalObserverPromotesToBackground()
+        {
+            var system = _distinctSystems[0];
+            system.SetActivityStateInternal(SystemActivityState.Stasis);
+            Assert.AreEqual(SystemActivityState.Stasis, system.ActivityState,
+                "Pre-condition: system should be Stasis.");
+
+            system.IncrementExternalObserver(false);
+            Assert.AreEqual(SystemActivityState.Background, system.ActivityState,
+                "System should be promoted to Background after gaining an external observer.");
+
+            system.DecrementExternalObserver(false);
+            Assert.AreEqual(SystemActivityState.Stasis, system.ActivityState,
+                "System should return to Stasis after losing external observer.");
+        }
+
+        [Test]
+        public void PriorityExternalObserverPromotesToForeground()
+        {
+            var system = _distinctSystems[0];
+            system.SetActivityStateInternal(SystemActivityState.Stasis);
+            Assert.AreEqual(SystemActivityState.Stasis, system.ActivityState,
+                "Pre-condition: system should be Stasis.");
+
+            system.IncrementExternalObserver(true);
+            Assert.AreEqual(SystemActivityState.Foreground, system.ActivityState,
+                "System should be promoted to Foreground after gaining a priority external observer.");
+
+            system.DecrementExternalObserver(true);
+            Assert.AreEqual(SystemActivityState.Stasis, system.ActivityState,
+                "System should return to Stasis after losing priority external observer.");
+        }
+
+        [Test]
+        public void ExternalObserverPromotionPromotesToForeground()
+        {
+            var system = _distinctSystems[0];
+            system.SetActivityStateInternal(SystemActivityState.Stasis);
+            Assert.AreEqual(SystemActivityState.Stasis, system.ActivityState,
+                "Pre-condition: system should be Stasis.");
+
+            system.IncrementExternalObserver(false);
+            Assert.AreEqual(SystemActivityState.Background, system.ActivityState,
+                "System should be promoted to Background after gaining an external observer.");
+
+            system.PromoteExternalObserver();
+            Assert.AreEqual(SystemActivityState.Foreground, system.ActivityState,
+                "System should be promoted to Foreground after promoting an external observer.");
+
+            system.DemoteExternalObserver();
+            Assert.AreEqual(SystemActivityState.Background, system.ActivityState,
+                "System should return to Background after demoting an external observer.");
+
+            system.DecrementExternalObserver(false);
+            Assert.AreEqual(SystemActivityState.Stasis, system.ActivityState,
+                "System should return to Stasis after losing all external observers.");
+        }
+
+        [Test]
+        public void MultipleExternalObserversMaintainState()
+        {
+            var system = _distinctSystems[0];
+            system.SetActivityStateInternal(SystemActivityState.Stasis);
+            Assert.AreEqual(SystemActivityState.Stasis, system.ActivityState,
+                "Pre-condition: system should be Stasis.");
+
+            system.IncrementExternalObserver(false);
+            system.IncrementExternalObserver(false);
+            Assert.AreEqual(SystemActivityState.Background, system.ActivityState,
+                "System should be Background with multiple external observers.");
+
+            system.IncrementExternalObserver(true);
+            Assert.AreEqual(SystemActivityState.Foreground, system.ActivityState,
+                "System should be Foreground with a priority external observer.");
+
+            system.DecrementExternalObserver(true);
+            Assert.AreEqual(SystemActivityState.Background, system.ActivityState,
+                "System should return to Background after losing priority external observer.");
+
+            system.DecrementExternalObserver(false);
+            Assert.AreEqual(SystemActivityState.Background, system.ActivityState,
+                "System should remain Background with one remaining external observer.");
+
+            system.DecrementExternalObserver(false);
+            Assert.AreEqual(SystemActivityState.Stasis, system.ActivityState,
+                "System should return to Stasis after losing all external observers.");
+        }
     }
 }


### PR DESCRIPTION
The change aims to remove external code needing to decide the system's new state.

External code will instead submit requests for a "minimum" simulation state. The system itself will then evaluate what the "minimum" simulation state needs to be and update it accordingly. This change centralizes the decision rules to the method `UpdateActivityState()`.


Possible future enhancements:
- Better naming of the feature.
- Improve deterministic behaviour by deferring `UpdateActivityState` to the main game loop, instead of executing immediately.
- Add object wrappers based on `IDisposable` that automatically decrement the counters when disposed for easier tracking.