### PR TITLE
Restructure UI window base class hierarchy.

### DIFF
--- a/Pulsar4X/Pulsar4X.Client.Host/Designer/ComponentDesignWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client.Host/Designer/ComponentDesignWindow.cs
@@ -22,14 +22,12 @@ namespace Pulsar4X.Client
 
         internal static ComponentDesignWindow GetInstance()
         {
-            ComponentDesignWindow thisitem;
-            if (!_uiState.LoadedWindows.ContainsKey(typeof(ComponentDesignWindow)))
+            if(_uiState.TryGetUniqueWindow<ComponentDesignWindow>(out var window))
             {
-                thisitem = new ComponentDesignWindow();
+                return window;
             }
-            thisitem = (ComponentDesignWindow)_uiState.LoadedWindows[typeof(ComponentDesignWindow)];
 
-            return thisitem;
+            return _uiState.AddUniqueWindow(new ComponentDesignWindow());
         }
 
         private static void RefreshDerivedData(ComponentDesignsSnapshot snapshot)

--- a/Pulsar4X/Pulsar4X.Client.Host/Designer/ComponentDesignWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client.Host/Designer/ComponentDesignWindow.cs
@@ -152,9 +152,5 @@ namespace Pulsar4X.Client
             ImGui.EndDisabled();
 
         }
-
-        public override void OnGameTickChange(DateTime newDate)
-        {
-        }
     }
 }

--- a/Pulsar4X/Pulsar4X.Client.Host/Designer/ComponentDesignWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client.Host/Designer/ComponentDesignWindow.cs
@@ -8,7 +8,7 @@ using Pulsar4X.Client.Interface.Widgets;
 
 namespace Pulsar4X.Client
 {
-    public class ComponentDesignWindow : PulsarGuiWindow
+    public class ComponentDesignWindow : UniquePulsarGuiWindow<ComponentDesignWindow>
     {
         // Derived lookups, rebuilt only when a new ComponentDesignsSnapshot is pushed (reference
         // change) — the server pushes one on connect and whenever a design is created.

--- a/Pulsar4X/Pulsar4X.Client.Host/Designer/ComponentsWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client.Host/Designer/ComponentsWindow.cs
@@ -22,17 +22,12 @@ public class ComponentsWindow : UniquePulsarGuiWindow<ComponentsWindow>
 
     public static ComponentsWindow GetInstance()
     {
-        ComponentsWindow instance;
-        if (!_uiState.LoadedWindows.ContainsKey(typeof(ComponentsWindow)))
+        if(_uiState.TryGetUniqueWindow<ComponentsWindow>(out var window))
         {
-            instance = new ComponentsWindow();
-        }
-        else
-        {
-            instance = (ComponentsWindow)_uiState.LoadedWindows[typeof(ComponentsWindow)];
+            return window;
         }
 
-        return instance;
+        return _uiState.AddUniqueWindow(new ComponentsWindow());
     }
 
     private void DisplayComponentCategory(string label, List<string> templateIds, List<string> designIds, FactionInfoDB factionInfoDB)

--- a/Pulsar4X/Pulsar4X.Client.Host/Designer/ComponentsWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client.Host/Designer/ComponentsWindow.cs
@@ -12,7 +12,7 @@ using System.Numerics;
 
 namespace Pulsar4X.Client.Interface.Windows;
 
-public class ComponentsWindow : PulsarGuiWindow
+public class ComponentsWindow : UniquePulsarGuiWindow<ComponentsWindow>
 {
     private string _selectedItemId = "";
     private object? _selectedItem = null;

--- a/Pulsar4X/Pulsar4X.Client.Host/Designer/ShipDesignWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client.Host/Designer/ShipDesignWindow.cs
@@ -23,7 +23,7 @@ using Pulsar4X.Client.Host;
 
 namespace Pulsar4X.Client
 {
-    public class ShipDesignWindow : PulsarGuiWindow
+    public class ShipDesignWindow : UniquePulsarGuiWindow<ShipDesignWindow>
     {
         private bool ShowNoDesigns = false;
         private byte[] SelectedDesignName =  Utils.BytesFromString("foo", 32);

--- a/Pulsar4X/Pulsar4X.Client.Host/Designer/ShipDesignWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client.Host/Designer/ShipDesignWindow.cs
@@ -129,17 +129,15 @@ namespace Pulsar4X.Client
 
         internal static ShipDesignWindow GetInstance()
         {
-            ShipDesignWindow thisitem;
-            if (!_uiState.LoadedWindows.ContainsKey(typeof(ShipDesignWindow)))
+            if(_uiState.TryGetUniqueWindow<ShipDesignWindow>(out var window))
             {
-                thisitem = new ShipDesignWindow();
-                thisitem.RefreshComponentDesigns();
-                thisitem.RefreshExistingClasses();
+                return window;
             }
-            else
-                thisitem = (ShipDesignWindow)_uiState.LoadedWindows[typeof(ShipDesignWindow)];
 
-            return thisitem;
+            window = _uiState.AddUniqueWindow(new ShipDesignWindow());
+            window.RefreshComponentDesigns();
+            window.RefreshExistingClasses();
+            return window;
         }
 
         void RefreshComponentDesigns()

--- a/Pulsar4X/Pulsar4X.Client.Host/DevTools/BlueprintsWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client.Host/DevTools/BlueprintsWindow.cs
@@ -22,17 +22,12 @@ public class BlueprintsWindow : UniquePulsarGuiWindow<BlueprintsWindow>
 
     public static BlueprintsWindow GetInstance()
     {
-        BlueprintsWindow instance;
-        if (!_uiState.LoadedWindows.ContainsKey(typeof(BlueprintsWindow)))
+        if(_uiState.TryGetUniqueWindow<BlueprintsWindow>(out var window))
         {
-            instance = new BlueprintsWindow();
-        }
-        else
-        {
-            instance = (BlueprintsWindow)_uiState.LoadedWindows[typeof(BlueprintsWindow)];
+            return window;
         }
 
-        return instance;
+        return _uiState.AddUniqueWindow(new BlueprintsWindow());
     }
 
     private void DisplayBlueprintCategory(string label, List<string> items)

--- a/Pulsar4X/Pulsar4X.Client.Host/DevTools/BlueprintsWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client.Host/DevTools/BlueprintsWindow.cs
@@ -12,7 +12,7 @@ using Pulsar4X.Client.Host;
 
 namespace Pulsar4X.Client.Interface.Windows;
 
-public class BlueprintsWindow : PulsarGuiWindow
+public class BlueprintsWindow : UniquePulsarGuiWindow<BlueprintsWindow>
 {
 
     List<object> _editStack = new List<object>();

--- a/Pulsar4X/Pulsar4X.Client.Host/DevTools/DamageViewerWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client.Host/DevTools/DamageViewerWindow.cs
@@ -21,7 +21,7 @@ using Pulsar4X.Client.Host;
 
 namespace Pulsar4X.Client
 {
-    public class DamageViewerWindow : PulsarGuiWindow
+    public class DamageViewerWindow : UniquePulsarGuiWindow<DamageViewerWindow>
     {
         //private ComponentDesign _componentDesign;
         private Entity? _selectedEntity;

--- a/Pulsar4X/Pulsar4X.Client.Host/DevTools/DamageViewerWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client.Host/DevTools/DamageViewerWindow.cs
@@ -77,24 +77,23 @@ namespace Pulsar4X.Client
 
         public static DamageViewerWindow GetInstance()
         {
-            if (!_uiState.LoadedWindows.ContainsKey(typeof(DamageViewerWindow)))
+            if(_uiState.TryGetUniqueWindow<DamageViewerWindow>(out var window))
             {
-                var dv = new DamageViewerWindow();
-                if (_uiState.LastClickedEntity?.GetEntity() != null)
+                if (_uiState.PrimaryEntity != null && _uiState.LastClickedEntity.GetEntity()! != window._selectedEntity)
                 {
-                    dv.Init(_uiState.LastClickedEntity.GetEntity()!);
+                    window.Init(_uiState.LastClickedEntity.GetEntity()!);
                 }
-
-                return dv;
+                return window;
             }
-            else
+
+            window = _uiState.AddUniqueWindow(new DamageViewerWindow());
+
+            if (_uiState.LastClickedEntity?.GetEntity() != null)
             {
-                var dv = (DamageViewerWindow)_uiState.LoadedWindows[typeof(DamageViewerWindow)];
-                if (_uiState.PrimaryEntity != null && _uiState.LastClickedEntity.GetEntity()! != dv._selectedEntity)
-                    dv.Init(_uiState.LastClickedEntity.GetEntity()!);
-                return dv;
+                window.Init(_uiState.LastClickedEntity.GetEntity()!);
             }
 
+            return window;
         }
 
         private void Init(Entity damageableEntity)

--- a/Pulsar4X/Pulsar4X.Client.Host/DevTools/DataViewerWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client.Host/DevTools/DataViewerWindow.cs
@@ -17,7 +17,7 @@ using Pulsar4X.Client.Host;
 
 namespace Pulsar4X.Client;
 
-public class DataViewerWindow : PulsarGuiWindow
+public class DataViewerWindow : UniquePulsarGuiWindow<DataViewerWindow>
 {
 
     SystemState? _systemState;

--- a/Pulsar4X/Pulsar4X.Client.Host/DevTools/DataViewerWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client.Host/DevTools/DataViewerWindow.cs
@@ -25,19 +25,20 @@ public class DataViewerWindow : UniquePulsarGuiWindow<DataViewerWindow>
 
     internal static DataViewerWindow GetInstance()
     {
-        DataViewerWindow instance;
-        if (!_uiState.LoadedWindows.ContainsKey(typeof(DataViewerWindow)))
-            instance = new DataViewerWindow(GameLifecycle.Instance?.Game?.StartingGameData);
-        else
+        if(!_uiState.TryGetUniqueWindow<DataViewerWindow>(out var window))
         {
-            instance = (DataViewerWindow)_uiState.LoadedWindows[typeof(DataViewerWindow)];
+            window = _uiState.AddUniqueWindow(new DataViewerWindow(GameLifecycle.Instance?.Game?.StartingGameData));
         }
 
         if (_uiState.IsGameLoaded && !string.IsNullOrEmpty(_uiState.SelectedStarSystemId))
-            instance._systemState = GameLifecycle.Instance?.SelectedSystemState;
+        {
+            window._systemState = GameLifecycle.Instance?.SelectedSystemState;
+        }
         else
-            instance._systemState = null;
-        return instance;
+        {
+            window._systemState = null;
+        }
+        return window;
     }
 
     private DataViewerWindow(ModDataStore modDataStore)

--- a/Pulsar4X/Pulsar4X.Client.Host/DevTools/DebugGUIWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client.Host/DevTools/DebugGUIWindow.cs
@@ -39,14 +39,5 @@ namespace Pulsar4X.Client
                 ImGui.End();
             }
         }
-
-
-        public override void OnGameTickChange(DateTime newDate)
-        {
-        }
-
-        public override void OnSystemTickChange(DateTime newDate)
-        {
-        }
     }
 }

--- a/Pulsar4X/Pulsar4X.Client.Host/DevTools/DebugGUIWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client.Host/DevTools/DebugGUIWindow.cs
@@ -3,7 +3,7 @@ using ImGuiNET;
 
 namespace Pulsar4X.Client
 {
-    public class DebugGUIWindow : PulsarGuiWindow
+    public class DebugGUIWindow : UniquePulsarGuiWindow<DebugGUIWindow>
     {
 
         private DebugGUIWindow()

--- a/Pulsar4X/Pulsar4X.Client.Host/DevTools/DebugGUIWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client.Host/DevTools/DebugGUIWindow.cs
@@ -12,20 +12,13 @@ namespace Pulsar4X.Client
         }
         internal static DebugGUIWindow GetInstance()
         {
-            DebugGUIWindow instance;
-            if (!_uiState.LoadedWindows.ContainsKey(typeof(DebugGUIWindow)))
-                instance = new DebugGUIWindow();
-            else
+            if(_uiState.TryGetUniqueWindow<DebugGUIWindow>(out var window))
             {
-                instance = (DebugGUIWindow)_uiState.LoadedWindows[typeof(DebugGUIWindow)];
-
+                return window;
             }
 
-            return instance;
+            return _uiState.AddUniqueWindow(new DebugGUIWindow());
         }
-
-
-
 
         internal override void Display()
         {

--- a/Pulsar4X/Pulsar4X.Client.Host/DevTools/DebugWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client.Host/DevTools/DebugWindow.cs
@@ -1399,9 +1399,5 @@ namespace Pulsar4X.Client
 
             if(SystemState == null) return;
         }
-
-        public override void OnGameTickChange(DateTime newDate)
-        {
-        }
     }
 }

--- a/Pulsar4X/Pulsar4X.Client.Host/DevTools/DebugWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client.Host/DevTools/DebugWindow.cs
@@ -90,24 +90,26 @@ namespace Pulsar4X.Client
         }
         internal static DebugWindow GetInstance()
         {
-            DebugWindow instance;
-            if (!_uiState.LoadedWindows.ContainsKey(typeof(DebugWindow)))
-                instance = new DebugWindow();
-            else
+            if(!_uiState.TryGetUniqueWindow<DebugWindow>(out var window))
             {
-                instance = (DebugWindow)_uiState.LoadedWindows[typeof(DebugWindow)];
-                if (_uiState.IsGameLoaded)
-                    instance.RefreshFactionEntites(_uiState);
-                //if(_uiState.LastClickedEntity?.Entity != null)
-                //    instance.SelectedEntity = _uiState.LastClickedEntity.Entity;
+                window = new DebugWindow();
             }
-            //if(_uiState.LastClickedEntity?.Entity != null && instance.SelectedEntity != _uiState.LastClickedEntity.Entity)
-            //    instance.SelectedEntity = _uiState.LastClickedEntity.Entity;
-            if (_uiState.IsGameLoaded && !string.IsNullOrEmpty(_uiState.SelectedStarSystemId))
-                instance.SystemState = GameLifecycle.Instance?.SelectedSystemState;
-            else
-                instance.SystemState = null;
-            return instance;
+
+            if(_uiState.IsGameLoaded)
+            {
+                window.RefreshFactionEntites(_uiState);
+
+                if(!string.IsNullOrEmpty(_uiState.SelectedStarSystemId))
+                {
+                    // TODO: Remove dependency on GameLifecycle Sinleton.
+                    window.SystemState = GameLifecycle.Instance?.SelectedSystemState;
+                }
+                else
+                {
+                    window.SystemState = null;
+                }
+            }
+            return window;
         }
 
         internal void SetGameEvents()

--- a/Pulsar4X/Pulsar4X.Client.Host/DevTools/DebugWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client.Host/DevTools/DebugWindow.cs
@@ -25,7 +25,7 @@ using Pulsar4X.Client.Host;
 
 namespace Pulsar4X.Client
 {
-    public class DebugWindow : PulsarGuiWindow
+    public class DebugWindow : UniquePulsarGuiWindow<DebugWindow>
     {
         EntityState? _selectedEntityState;
 

--- a/Pulsar4X/Pulsar4X.Client.Host/DevTools/OrbitalDebugWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client.Host/DevTools/OrbitalDebugWindow.cs
@@ -29,18 +29,17 @@ namespace Pulsar4X.Client
 
         public static OrbitalDebugWindow GetInstance()
         {
-            if(_orbitalDebugWindow == null)
-                _orbitalDebugWindow = new OrbitalDebugWindow();
-
-            if(_uiState.LastClickedEntity != null)
+            if(!_uiState.TryGetUniqueWindow<OrbitalDebugWindow>(out var window))
             {
-                if (_orbitalDebugWindow._debugWidget == null ||
-                    _orbitalDebugWindow._debugWidget.EntityGuid != _uiState.LastClickedEntity.Id)
-                {
-                    _orbitalDebugWindow.HardRefresh();
-                }
+                window = _uiState.AddUniqueWindow(new OrbitalDebugWindow());
             }
-            return _orbitalDebugWindow;
+
+            if (_uiState.LastClickedEntity != null && (window._debugWidget == null ||
+                    window._debugWidget.EntityGuid != _uiState.LastClickedEntity.Id))
+            {
+                window.HardRefresh();
+            }
+            return window;
         }
 
 

--- a/Pulsar4X/Pulsar4X.Client.Host/DevTools/OrbitalDebugWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client.Host/DevTools/OrbitalDebugWindow.cs
@@ -18,7 +18,7 @@ namespace Pulsar4X.Client
 {
 
 
-    public class OrbitalDebugWindow : PulsarGuiWindow
+    public class OrbitalDebugWindow : UniquePulsarGuiWindow<OrbitalDebugWindow>
     {
         public static OrbitalDebugWindow? _orbitalDebugWindow;
         OrbitalDebugWidget? _debugWidget;
@@ -216,7 +216,7 @@ namespace Pulsar4X.Client
         {
             _entity = entityState.GetEntity()!;
             _bodyPosition = new PositionDBAdapter(_entity.GetDataBlob<PositionDB>());
-            _orbitIcon = PulsarGuiWindow._uiState.SelectedSysMapRender?.GetOrbitIcon(entityState.Id);
+            _orbitIcon = UniquePulsarGuiWindow._uiState.SelectedSysMapRender?.GetOrbitIcon(entityState.Id);
 
             //NOTE! ParentPositionDB references the focal point (ie parent's position) *not* the orbiting object position.
 

--- a/Pulsar4X/Pulsar4X.Client.Host/DevTools/PerformanceWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client.Host/DevTools/PerformanceWindow.cs
@@ -15,7 +15,7 @@ using Pulsar4X.Client.Host;
 namespace Pulsar4X.Client
 {
 
-    public class PerformanceWindow : PulsarGuiWindow
+    public class PerformanceWindow : UniquePulsarGuiWindow<PerformanceWindow>
     {
         Stopwatch _sw = new Stopwatch();
 

--- a/Pulsar4X/Pulsar4X.Client.Host/DevTools/PerformanceWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client.Host/DevTools/PerformanceWindow.cs
@@ -375,10 +375,5 @@ namespace Pulsar4X.Client
             else
                 _gameRateIndex++;
         }
-
-        public override void OnSystemTickChange(DateTime newDate)
-        {
-
-        }
     }
 }

--- a/Pulsar4X/Pulsar4X.Client.Host/DevTools/PerformanceWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client.Host/DevTools/PerformanceWindow.cs
@@ -55,18 +55,21 @@ namespace Pulsar4X.Client
         }
         internal static PerformanceWindow GetInstance()
         {
-            PerformanceWindow instance;
-            if (!_uiState.LoadedWindows.ContainsKey(typeof(PerformanceWindow)))
-                instance = new PerformanceWindow();
+            if(!_uiState.TryGetUniqueWindow<PerformanceWindow>(out var window))
+            {
+                window = _uiState.AddUniqueWindow(new PerformanceWindow());
+            }
+
+            if (_uiState.IsGameLoaded && !string.IsNullOrEmpty(_uiState.SelectedStarSystemId))
+            {
+                // TODO: Remove dependency on GameLifecycle singleton.
+                window._systemState = GameLifecycle.Instance?.SelectedSystemState;
+            }
             else
             {
-                instance = (PerformanceWindow)_uiState.LoadedWindows[typeof(PerformanceWindow)];
+                window._systemState = null;
             }
-            if (_uiState.IsGameLoaded && !string.IsNullOrEmpty(_uiState.SelectedStarSystemId))
-                instance._systemState = GameLifecycle.Instance?.SelectedSystemState;
-            else
-                instance._systemState = null;
-            return instance;
+            return window;
         }
 
 

--- a/Pulsar4X/Pulsar4X.Client.Host/DevTools/SMWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client.Host/DevTools/SMWindow.cs
@@ -12,7 +12,7 @@ using Pulsar4X.Client.Host;
 
 namespace Pulsar4X.Client
 {
-    public class SMWindow : PulsarGuiWindow
+    public class SMWindow : UniquePulsarGuiWindow<SMWindow>
     {
         private Game? _game;
         private StarSystem? _currentSystem;

--- a/Pulsar4X/Pulsar4X.Client.Host/DevTools/SMWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client.Host/DevTools/SMWindow.cs
@@ -47,11 +47,12 @@ namespace Pulsar4X.Client
         //TODO auth of some kind.
         public static SMWindow GetInstance()
         {
-            if (!_uiState.LoadedWindows.ContainsKey(typeof(SMWindow)))
+            if(_uiState.TryGetUniqueWindow<SMWindow>(out var window))
             {
-                return new SMWindow();
+                return window;
             }
-            return (SMWindow)_uiState.LoadedWindows[typeof(SMWindow)];
+
+            return _uiState.AddUniqueWindow(new SMWindow());
         }
 
         void HardRefresh()

--- a/Pulsar4X/Pulsar4X.Client.Host/DevTools/SensorDraw.cs
+++ b/Pulsar4X/Pulsar4X.Client.Host/DevTools/SensorDraw.cs
@@ -75,36 +75,31 @@ namespace Pulsar4X.Client
         
         internal static SensorDraw GetInstance()
         {
-            SensorDraw instance;
-            if (!_uiState.LoadedWindows.ContainsKey(typeof(SensorDraw)))
-                instance = new SensorDraw();
-            else
+            if(!_uiState.TryGetUniqueWindow<SensorDraw>(out var window))
             {
-                instance = (SensorDraw)_uiState.LoadedWindows[typeof(SensorDraw)];
-                if(_uiState.LastClickedEntity?.GetEntity() != null)
-                    instance._selectedEntitySate = _uiState.LastClickedEntity;
-            }
-            if(instance._selectedEntitySate != null)
-            {
-                if (_uiState.LastClickedEntity?.GetEntity() != null && instance._selectedEntity != _uiState.LastClickedEntity.GetEntity()!)
-                    instance._selectedEntitySate = _uiState.LastClickedEntity;
-            }
-            else
-            {
-                if(_uiState.LastClickedEntity?.GetEntity() != null)
-                    instance._selectedEntitySate = _uiState.LastClickedEntity;
+                window = _uiState.AddUniqueWindow(new SensorDraw());
             }
 
-            if (_uiState.IsGameLoaded && !string.IsNullOrEmpty(_uiState.SelectedStarSystemId))
-                instance._selectedStarSysState = GameLifecycle.Instance?.SelectedSystemState;
-            else
-                instance._selectedStarSysState = null;
-            
-            if (instance._emitSensorProfile == null || instance._emitSensorProfile.OwningEntity != instance._selectedEntity)
+            if(_uiState.LastClickedEntity?.GetEntity() != null)
             {
-                instance.Setup();
+                window._selectedEntitySate = _uiState.LastClickedEntity;
             }
-            return instance;
+
+            if(_uiState.IsGameLoaded && !string.IsNullOrEmpty(_uiState.SelectedStarSystemId))
+            {
+                // TODO: Stop depending on GameLifecycle singleton.
+                window._selectedStarSysState = GameLifecycle.Instance?.SelectedSystemState;
+            }
+            else
+            {
+                window._selectedStarSysState = null;
+            }
+
+            if (window._emitSensorProfile == null || window._emitSensorProfile.OwningEntity != window._selectedEntity)
+            {
+                window.Setup();
+            }
+            return window;
         }
         internal override void Display()
         {

--- a/Pulsar4X/Pulsar4X.Client.Host/DevTools/SensorDraw.cs
+++ b/Pulsar4X/Pulsar4X.Client.Host/DevTools/SensorDraw.cs
@@ -19,7 +19,7 @@ using Pulsar4X.Client.Host;
 namespace Pulsar4X.Client
 {
     
-    public class SensorDraw : PulsarGuiWindow
+    public class SensorDraw : UniquePulsarGuiWindow<SensorDraw>
     {
         private EntityState? _selectedEntitySate;
         private Entity? _selectedEntity => _selectedEntitySate?.GetEntity();

--- a/Pulsar4X/Pulsar4X.Client.Host/ModFileEditing/ModFileEditor.cs
+++ b/Pulsar4X/Pulsar4X.Client.Host/ModFileEditing/ModFileEditor.cs
@@ -5,7 +5,7 @@ using Pulsar4X.Modding;
 
 namespace Pulsar4X.Client.ModFileEditing;
 
-public class ModFileEditor : PulsarGuiWindow
+public class ModFileEditor : UniquePulsarGuiWindow<ModFileEditor>
 {
     private ModInfoUI _modInfoUI;
     private TechBlueprintUI _techBlueprintUI;

--- a/Pulsar4X/Pulsar4X.Client/Input/SystemMapHotKeys.cs
+++ b/Pulsar4X/Pulsar4X.Client/Input/SystemMapHotKeys.cs
@@ -29,11 +29,11 @@ public class SystemMapHotKeys : IHotKeyHandler
             }
             else if(e.Key.Key == SDL.Keycode.F1)
             {
-                PulsarGuiWindow._uiState.ToggleDevTool("debug-window");
+                UniquePulsarGuiWindow._uiState.ToggleDevTool("debug-window");
             }
             else if(e.Key.Key == SDL.Keycode.F2)
             {
-                PulsarGuiWindow._uiState.ToggleDevTool("performance-window");
+                UniquePulsarGuiWindow._uiState.ToggleDevTool("performance-window");
             }
             else if(e.Key.Key == SDL.Keycode.F3)
             {
@@ -41,19 +41,19 @@ public class SystemMapHotKeys : IHotKeyHandler
             }
             else if(e.Key.Key == SDL.Keycode.F4)
             {
-                PulsarGuiWindow._uiState.ToggleDevTool("blueprints-window");
+                UniquePulsarGuiWindow._uiState.ToggleDevTool("blueprints-window");
             }
             else if(e.Key.Key == SDL.Keycode.F5)
             {
-                PulsarGuiWindow._uiState.ToggleDevTool("components-window");
+                UniquePulsarGuiWindow._uiState.ToggleDevTool("components-window");
             }
             else if(e.Key.Key == SDL.Keycode.Alpha1)
             {
-                PulsarGuiWindow._uiState.ToggleDevTool("component-design");
+                UniquePulsarGuiWindow._uiState.ToggleDevTool("component-design");
             }
             else if(e.Key.Key == SDL.Keycode.Alpha2)
             {
-                PulsarGuiWindow._uiState.ToggleDevTool("ship-design");
+                UniquePulsarGuiWindow._uiState.ToggleDevTool("ship-design");
             }
             else if(e.Key.Key == SDL.Keycode.Alpha3)
             {

--- a/Pulsar4X/Pulsar4X.Client/Interface/HUD/EntityFilterBar.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/HUD/EntityFilterBar.cs
@@ -26,11 +26,12 @@ public class EntityFilterBar : UniquePulsarGuiWindow<EntityFilterBar>
 
     internal static EntityFilterBar GetInstance()
     {
-        if (!_uiState.LoadedWindows.ContainsKey(typeof(EntityFilterBar)))
+        if(_uiState.TryGetUniqueWindow<EntityFilterBar>(out var window))
         {
-            return new EntityFilterBar();
+            return window;
         }
-        return (EntityFilterBar)_uiState.LoadedWindows[typeof(EntityFilterBar)];
+
+        return _uiState.AddUniqueWindow(new EntityFilterBar());
     }
 
     internal override void Display()

--- a/Pulsar4X/Pulsar4X.Client/Interface/HUD/EntityFilterBar.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/HUD/EntityFilterBar.cs
@@ -10,7 +10,7 @@ namespace Pulsar4X.Client;
 /// A small borderless toolbar in the upper right that provides toggle buttons
 /// for showing/hiding different entity types on the system map.
 /// </summary>
-public class EntityFilterBar : PulsarGuiWindow
+public class EntityFilterBar : UniquePulsarGuiWindow<EntityFilterBar>
 {
     private const string ViewKey = "map";
 

--- a/Pulsar4X/Pulsar4X.Client/Interface/HUD/Selector.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/HUD/Selector.cs
@@ -9,7 +9,7 @@ using Pulsar4X.Client.Interface.Widgets;
 
 namespace Pulsar4X.Client
 {
-    public class Selector : PulsarGuiWindow
+    public class Selector : UniquePulsarGuiWindow<Selector>
     {
         // When true the window shows the section editor instead of its normal content.
         private bool _editing = false;

--- a/Pulsar4X/Pulsar4X.Client/Interface/HUD/Selector.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/HUD/Selector.cs
@@ -51,12 +51,12 @@ namespace Pulsar4X.Client
 
         internal static Selector GetInstance()
         {
-            if (!_uiState.LoadedWindows.ContainsKey(typeof(Selector)))
+            if(_uiState.TryGetUniqueWindow<Selector>(out var window))
             {
-                return new Selector();
+                return window;
             }
 
-            return (Selector)_uiState.LoadedWindows[typeof(Selector)];
+            return _uiState.AddUniqueWindow(new Selector());
         }
 
         internal override void Display()

--- a/Pulsar4X/Pulsar4X.Client/Interface/HUD/TimeControl.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/HUD/TimeControl.cs
@@ -6,7 +6,7 @@ using Pulsar4X.Api;
 
 namespace Pulsar4X.Client
 {
-    public class TimeControl : PulsarGuiWindow
+    public class TimeControl : UniquePulsarGuiWindow<TimeControl>
     {
         // The client reads the clock from the galaxy model and submits changes as commands; it no
         // longer touches the engine's MasterTimePulse directly.

--- a/Pulsar4X/Pulsar4X.Client/Interface/HUD/TimeControl.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/HUD/TimeControl.cs
@@ -46,11 +46,12 @@ namespace Pulsar4X.Client
 
         internal static TimeControl GetInstance()
         {
-            if (!_uiState.LoadedWindows.ContainsKey(typeof(TimeControl)))
+            if(_uiState.TryGetUniqueWindow<TimeControl>(out var window))
             {
-                return new TimeControl();
+                return window;
             }
-            return (TimeControl)_uiState.LoadedWindows[typeof(TimeControl)];
+
+            return _uiState.AddUniqueWindow(new TimeControl());
         }
 
         private void Submit(TimeControlRequest request) => _uiState.GameClient?.SetTimeControlAsync(request);

--- a/Pulsar4X/Pulsar4X.Client/Interface/HUD/ToolBarWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/HUD/ToolBarWindow.cs
@@ -137,12 +137,12 @@ namespace Pulsar4X.Client
 
         internal static ToolBarWindow GetInstance()
         {
-            if (!UniquePulsarGuiWindow._uiState.LoadedWindows.ContainsKey(typeof(ToolBarWindow)))
+            if(_uiState.TryGetUniqueWindow<ToolBarWindow>(out var window))
             {
-                return new ToolBarWindow();
+                return window;
             }
 
-            return (ToolBarWindow)UniquePulsarGuiWindow._uiState.LoadedWindows[typeof(ToolBarWindow)];
+            return _uiState.AddUniqueWindow(new ToolBarWindow());
         }
 
         internal void SetButtons(List<ToolBarOption> buttons)

--- a/Pulsar4X/Pulsar4X.Client/Interface/HUD/ToolBarWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/HUD/ToolBarWindow.cs
@@ -7,7 +7,7 @@ using Pulsar4X.Client.Interface.Widgets;
 
 namespace Pulsar4X.Client
 {
-    public class ToolBarWindow : PulsarGuiWindow
+    public class ToolBarWindow : UniquePulsarGuiWindow<ToolBarWindow>
     {
         public Vector2 ButtonSize = new Vector2(32, 32);
         private uint UnClickedColour;
@@ -137,12 +137,12 @@ namespace Pulsar4X.Client
 
         internal static ToolBarWindow GetInstance()
         {
-            if (!PulsarGuiWindow._uiState.LoadedWindows.ContainsKey(typeof(ToolBarWindow)))
+            if (!UniquePulsarGuiWindow._uiState.LoadedWindows.ContainsKey(typeof(ToolBarWindow)))
             {
                 return new ToolBarWindow();
             }
 
-            return (ToolBarWindow)PulsarGuiWindow._uiState.LoadedWindows[typeof(ToolBarWindow)];
+            return (ToolBarWindow)UniquePulsarGuiWindow._uiState.LoadedWindows[typeof(ToolBarWindow)];
         }
 
         internal void SetButtons(List<ToolBarOption> buttons)

--- a/Pulsar4X/Pulsar4X.Client/Interface/Menus/EntityUIWindowSelector.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Menus/EntityUIWindowSelector.cs
@@ -6,7 +6,7 @@ using ImGuiNET;
 namespace Pulsar4X.Client
 {
     //basically an always open context menu for the currently selected entity.
-    public class EntityUIWindowSelector : PulsarGuiWindow
+    public class EntityUIWindowSelector : UniquePulsarGuiWindow<EntityUIWindowSelector>
     {
         public System.Numerics.Vector2 BtnSizes = new System.Numerics.Vector2(32, 32);
         private List<ToolbuttonData> StandardButtons = new List<ToolbuttonData>();

--- a/Pulsar4X/Pulsar4X.Client/Interface/Menus/EntityUIWindowSelector.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Menus/EntityUIWindowSelector.cs
@@ -29,20 +29,11 @@ namespace Pulsar4X.Client
 
         internal static EntityUIWindowSelector GetInstance()
         {
-            EntityUIWindowSelector thisItem;
-            if (!_uiState.LoadedWindows.ContainsKey(typeof(EntityUIWindowSelector)))
+            if(_uiState.TryGetUniqueWindow<EntityUIWindowSelector>(out var window))
             {
-                thisItem = new EntityUIWindowSelector();
+                return window;
             }
-            else
-            {
-                thisItem = (EntityUIWindowSelector)_uiState.LoadedWindows[typeof(EntityUIWindowSelector)];
-            }
-
-
-            return thisItem;
-
-
+            return _uiState.AddUniqueWindow(new EntityUIWindowSelector());
         }
         //displays selected entity info
 

--- a/Pulsar4X/Pulsar4X.Client/Interface/Menus/LoadGame.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Menus/LoadGame.cs
@@ -13,11 +13,11 @@ public class LoadGame : UniquePulsarGuiWindow<LoadGame>
 
     internal static LoadGame GetInstance()
     {
-        if (!_uiState.LoadedWindows.ContainsKey(typeof(LoadGame)))
+        if(_uiState.TryGetUniqueWindow<LoadGame>(out var window))
         {
-            return new LoadGame();
+            return window;
         }
-        return (LoadGame)_uiState.LoadedWindows[typeof(LoadGame)];
+        return _uiState.AddUniqueWindow(new LoadGame());
     }
 
     internal void LoadLatest()

--- a/Pulsar4X/Pulsar4X.Client/Interface/Menus/LoadGame.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Menus/LoadGame.cs
@@ -4,7 +4,7 @@ using Pulsar4X.Client.Interface.Widgets;
 
 namespace Pulsar4X.Client.Interface.Menus;
 
-public class LoadGame : PulsarGuiWindow
+public class LoadGame : UniquePulsarGuiWindow<LoadGame>
 {
     private string _filePath = Path.Combine(PulsarMainWindow.GetAppDataPath(), PulsarMainWindow.SavesPath);
     private string _fileName = "savegame";

--- a/Pulsar4X/Pulsar4X.Client/Interface/Menus/MainMenuItems.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Menus/MainMenuItems.cs
@@ -144,14 +144,6 @@ namespace Pulsar4X.Client
             ImGui.PopStyleVar();
         }
 
-        public override void OnGameTickChange(DateTime newDate)
-        {
-        }
-
-        public override void OnSystemTickChange(DateTime newDate)
-        {
-        }
-
         private bool DoAnySavesExist()
         {
             var appDataDirectory = PulsarMainWindow.GetAppDataPath();

--- a/Pulsar4X/Pulsar4X.Client/Interface/Menus/MainMenuItems.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Menus/MainMenuItems.cs
@@ -8,7 +8,7 @@ using System.Diagnostics;
 
 namespace Pulsar4X.Client
 {
-    public class MainMenuItems : PulsarGuiWindow
+    public class MainMenuItems : UniquePulsarGuiWindow<MainMenuItems>
     {
 
         bool _saveGame = false;

--- a/Pulsar4X/Pulsar4X.Client/Interface/Menus/MainMenuItems.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Menus/MainMenuItems.cs
@@ -17,11 +17,12 @@ namespace Pulsar4X.Client
         private MainMenuItems(){}
         internal static MainMenuItems GetInstance()
         {
-            if (!_uiState.LoadedWindows.ContainsKey(typeof(MainMenuItems)))
+            if(_uiState.TryGetUniqueWindow<MainMenuItems>(out var window))
             {
-                return new MainMenuItems();
+                return window;
             }
-            return (MainMenuItems)_uiState.LoadedWindows[typeof(MainMenuItems)];
+
+            return _uiState.AddUniqueWindow(new MainMenuItems());
         }
 
 

--- a/Pulsar4X/Pulsar4X.Client/Interface/Menus/NewGameMenu.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Menus/NewGameMenu.cs
@@ -24,7 +24,7 @@ static class Helper
     }
 }
 
-public class NewGameMenu : PulsarGuiWindow
+public class NewGameMenu : UniquePulsarGuiWindow<NewGameMenu>
 {
     private const int NAME_BUFFER_SIZE = 32;
     private const int SHORTNAME_BUFFER_SIZE = 5;

--- a/Pulsar4X/Pulsar4X.Client/Interface/Menus/NewGameMenu.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Menus/NewGameMenu.cs
@@ -72,13 +72,15 @@ public class NewGameMenu : UniquePulsarGuiWindow<NewGameMenu>
     {
         _masterSeed = RandomNumberGenerator.GetInt32(999999999);
     }
+
     internal static NewGameMenu GetInstance()
     {
-        if (!_uiState.LoadedWindows.ContainsKey(typeof(NewGameMenu)))
+        if(_uiState.TryGetUniqueWindow<NewGameMenu>(out var window))
         {
-            return new NewGameMenu();
+            return window;
         }
-        return (NewGameMenu)_uiState.LoadedWindows[typeof(NewGameMenu)];
+
+        return _uiState.AddUniqueWindow(new NewGameMenu());
     }
 
     internal override void Display()

--- a/Pulsar4X/Pulsar4X.Client/Interface/Menus/SaveGame.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Menus/SaveGame.cs
@@ -13,11 +13,11 @@ public class SaveGame : UniquePulsarGuiWindow<SaveGame>
 
     internal static SaveGame GetInstance()
     {
-        if (!_uiState.LoadedWindows.ContainsKey(typeof(SaveGame)))
+        if(_uiState.TryGetUniqueWindow<SaveGame>(out var window))
         {
-            return new SaveGame();
+            return window;
         }
-        return (SaveGame)_uiState.LoadedWindows[typeof(SaveGame)];
+        return _uiState.AddUniqueWindow(new SaveGame());
     }
 
     internal override void Display()

--- a/Pulsar4X/Pulsar4X.Client/Interface/Menus/SaveGame.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Menus/SaveGame.cs
@@ -4,7 +4,7 @@ using Pulsar4X.Client.Interface.Widgets;
 
 namespace Pulsar4X.Client.Interface.Menus;
 
-public class SaveGame : PulsarGuiWindow
+public class SaveGame : UniquePulsarGuiWindow<SaveGame>
 {
     private string _filePath = Path.Combine(PulsarMainWindow.GetAppDataPath(), PulsarMainWindow.SavesPath);
     private string _fileName = "savegame.sav";

--- a/Pulsar4X/Pulsar4X.Client/Interface/Menus/SettingsWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Menus/SettingsWindow.cs
@@ -37,11 +37,12 @@ namespace Pulsar4X.Client
         }
         internal static SettingsWindow GetInstance()
         {
-            if (!_uiState.LoadedWindows.ContainsKey(typeof(SettingsWindow)))
+            if(_uiState.TryGetUniqueWindow<SettingsWindow>(out var window))
             {
-                return new SettingsWindow();
+                return window;
             }
-            return (SettingsWindow)_uiState.LoadedWindows[typeof(SettingsWindow)];
+
+            return _uiState.AddUniqueWindow(new SettingsWindow());
         }
 
         internal override void Display()

--- a/Pulsar4X/Pulsar4X.Client/Interface/Menus/SettingsWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Menus/SettingsWindow.cs
@@ -7,7 +7,7 @@ using Pulsar4X.Client.Interface.Widgets;
 
 namespace Pulsar4X.Client
 {
-    public class SettingsWindow : PulsarGuiWindow
+    public class SettingsWindow : UniquePulsarGuiWindow<SettingsWindow>
     {
         ImGuiTreeNodeFlags _xpanderFlags = ImGuiTreeNodeFlags.CollapsingHeader;
         List<List<UserOrbitSettings>> _userOrbitSettingsMtx;

--- a/Pulsar4X/Pulsar4X.Client/Interface/Menus/SystemViewPreferences.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Menus/SystemViewPreferences.cs
@@ -14,7 +14,7 @@ namespace Pulsar4X.Client;
 /// but also loads and saves the preferences and holds the
 /// currently selected views for various parts of the game.
 /// </summary>
-public class SystemViewPreferences : PulsarGuiWindow
+public class SystemViewPreferences : UniquePulsarGuiWindow<SystemViewPreferences>
 {
     internal record View
     {

--- a/Pulsar4X/Pulsar4X.Client/Interface/Menus/SystemViewPreferences.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Menus/SystemViewPreferences.cs
@@ -82,12 +82,12 @@ public class SystemViewPreferences : UniquePulsarGuiWindow<SystemViewPreferences
 
     internal static SystemViewPreferences GetInstance()
     {
-        if (!_uiState.LoadedWindows.ContainsKey(typeof(SystemViewPreferences)))
+        if(_uiState.TryGetUniqueWindow<SystemViewPreferences>(out var window))
         {
-            return new SystemViewPreferences();
+            return window;
         }
 
-        return (SystemViewPreferences)_uiState.LoadedWindows[typeof(SystemViewPreferences)];
+        return _uiState.AddUniqueWindow(new SystemViewPreferences());
     }
 
     internal SystemViewPreferences()

--- a/Pulsar4X/Pulsar4X.Client/Interface/Widgets/ResultModal.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Widgets/ResultModal.cs
@@ -3,7 +3,7 @@ using ImGuiNET;
 
 namespace Pulsar4X.Client.Interface.Widgets;
 
-public class ResultModal : PulsarGuiWindow
+public class ResultModal : UniquePulsarGuiWindow<ResultModal>
 {
     private byte[]? _inputBuffer = null;
     uint _bufferMaxSize = 64;

--- a/Pulsar4X/Pulsar4X.Client/Interface/Widgets/ResultModal.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Widgets/ResultModal.cs
@@ -17,11 +17,12 @@ public class ResultModal : UniquePulsarGuiWindow<ResultModal>
 
     internal static ResultModal GetInstance()
     {
-        if (!_uiState.LoadedWindows.ContainsKey(typeof(ResultModal)))
+        if(_uiState.TryGetUniqueWindow<ResultModal>(out var window))
         {
-            return new ResultModal();
+            return window;
         }
-        return (ResultModal)_uiState.LoadedWindows[typeof(ResultModal)];
+
+        return _uiState.AddUniqueWindow(new ResultModal());
     }
 
     internal override void Display()

--- a/Pulsar4X/Pulsar4X.Client/Interface/Widgets/TextModal.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Widgets/TextModal.cs
@@ -3,7 +3,7 @@ using ImGuiNET;
 
 namespace Pulsar4X.Client.Interface.Widgets;
 
-public class TextModal : PulsarGuiWindow
+public class TextModal : UniquePulsarGuiWindow<TextModal>
 {
     private byte[]? _inputBuffer = null;
     uint _bufferMaxSize = 64;

--- a/Pulsar4X/Pulsar4X.Client/Interface/Widgets/TextModal.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Widgets/TextModal.cs
@@ -16,12 +16,12 @@ public class TextModal : UniquePulsarGuiWindow<TextModal>
 
     internal static TextModal GetInstance()
     {
-        if (!_uiState.LoadedWindows.ContainsKey(typeof(TextModal)))
+        if(_uiState.TryGetUniqueWindow<TextModal>(out var window))
         {
-            return new TextModal();
+            return window;
         }
 
-        return (TextModal)_uiState.LoadedWindows[typeof(TextModal)];
+        return _uiState.AddUniqueWindow(new TextModal());
     }
 
     internal override void Display()

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/ColonyManagementWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/ColonyManagementWindow.cs
@@ -8,7 +8,7 @@ using Pulsar4X.Client.Interface.Widgets;
 
 namespace Pulsar4X.Client
 {
-    public class ColonyManagementWindow : PulsarGuiWindow
+    public class ColonyManagementWindow : UniquePulsarGuiWindow<ColonyManagementWindow>
     {
         private Dictionary<string, bool> isExpanded = new();
 

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/ColonyManagementWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/ColonyManagementWindow.cs
@@ -19,14 +19,12 @@ namespace Pulsar4X.Client
 
         internal static ColonyManagementWindow GetInstance()
         {
-            ColonyManagementWindow thisitem;
-            if (!_uiState.LoadedWindows.ContainsKey(typeof(ColonyManagementWindow)))
+            if(_uiState.TryGetUniqueWindow<ColonyManagementWindow>(out var window))
             {
-                thisitem = new ColonyManagementWindow();
+                return window;
             }
-            thisitem = (ColonyManagementWindow)_uiState.LoadedWindows[typeof(ColonyManagementWindow)];
 
-            return thisitem;
+            return _uiState.AddUniqueWindow(new ColonyManagementWindow());
         }
 
         public void SelectColony(int colonyId, string systemId)

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/CommanderWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/CommanderWindow.cs
@@ -13,7 +13,7 @@ namespace Pulsar4X.Client
     /// with a details pane for the selected person on the right. Reads the API galaxy model
     /// (Galaxy.Commanders, pushed on connect, clock advances, and after accepted commands).
     /// </summary>
-    public class CommanderWindow : PulsarGuiWindow
+    public class CommanderWindow : UniquePulsarGuiWindow<CommanderWindow>
     {
         // Selection is by commander id, re-resolved each frame: the roster is replaced wholesale
         // by server pushes.

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/CommanderWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/CommanderWindow.cs
@@ -25,11 +25,12 @@ namespace Pulsar4X.Client
 
         internal static CommanderWindow GetInstance()
         {
-            if (!_uiState.LoadedWindows.ContainsKey(typeof(CommanderWindow)))
+            if(_uiState.TryGetUniqueWindow<CommanderWindow>(out var window))
             {
-                return new CommanderWindow();
+                return window;
             }
-            return (CommanderWindow)_uiState.LoadedWindows[typeof(CommanderWindow)];
+
+            return _uiState.AddUniqueWindow(new CommanderWindow());
         }
 
         internal override void Display()

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/CreateTransferWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/CreateTransferWindow.cs
@@ -19,7 +19,12 @@ public class CreateTransferWindow : UniquePulsarGuiWindow<CreateTransferWindow>
 
     internal static CreateTransferWindow GetInstance()
     {
-        return _uiState.LoadedWindows.ContainsKey(typeof(CreateTransferWindow)) ? (CreateTransferWindow)_uiState.LoadedWindows[typeof(CreateTransferWindow)] : new CreateTransferWindow();
+        if(_uiState.TryGetUniqueWindow<CreateTransferWindow>(out var window))
+        {
+            return window;
+        }
+
+        return _uiState.AddUniqueWindow(new CreateTransferWindow());
     }
 
     public void SetLeft(int entityId, string systemId)

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/CreateTransferWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/CreateTransferWindow.cs
@@ -7,7 +7,7 @@ using Pulsar4X.Client.Interface.Widgets;
 
 namespace Pulsar4X.Client;
 
-public class CreateTransferWindow : PulsarGuiWindow
+public class CreateTransferWindow : UniquePulsarGuiWindow<CreateTransferWindow>
 {
     private int? _leftId;
     private int? _rightId;

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/DistanceRuler.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/DistanceRuler.cs
@@ -51,21 +51,12 @@ namespace Pulsar4X.Client
         }
 
         internal static DistanceRuler GetInstance() {
-
-            DistanceRuler thisItem;
-            if (!_uiState.LoadedWindows.ContainsKey(typeof(DistanceRuler)))
+            if(_uiState.TryGetUniqueWindow<DistanceRuler>(out var window))
             {
-                thisItem = new DistanceRuler();
-            }
-            else
-            {
-                thisItem = (DistanceRuler)_uiState.LoadedWindows[typeof(DistanceRuler)];
+                return window;
             }
 
-
-            return thisItem;
-
-
+            return _uiState.AddUniqueWindow(new DistanceRuler());
         }
 
         internal override void Display()

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/DistanceRuler.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/DistanceRuler.cs
@@ -119,13 +119,5 @@ namespace Pulsar4X.Client
             Window.End();
 
         }
-
-        public override void OnGameTickChange(DateTime newDate)
-        {
-        }
-
-        public override void OnSystemTickChange(DateTime newDate)
-        {
-        }
     }
 }

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/DistanceRuler.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/DistanceRuler.cs
@@ -6,7 +6,7 @@ using Stringify = Pulsar4X.Api.Stringify;
 
 namespace Pulsar4X.Client
 {
-    class DistanceRuler : PulsarGuiWindow
+    class DistanceRuler : UniquePulsarGuiWindow<DistanceRuler>
     {
         //measuring variables
         //measuring booleans

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/EntityUIWindows.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/EntityUIWindows.cs
@@ -5,7 +5,7 @@ using Pulsar4X.Api;
 namespace Pulsar4X.Client
 {
     //a do nothing helper class that is plugged into generics for static checks
-    public class PinCameraBlankMenuHelper : PulsarGuiWindow
+    public class PinCameraBlankMenuHelper : UniquePulsarGuiWindow<PinCameraBlankMenuHelper>
     {
         internal override void Display()
         {
@@ -13,7 +13,7 @@ namespace Pulsar4X.Client
     }
 
     //a do nothing helper class that is plugged into generics for static checks
-    public class GotoSystemBlankMenuHelper : PulsarGuiWindow
+    public class GotoSystemBlankMenuHelper : UniquePulsarGuiWindow<GotoSystemBlankMenuHelper>
     {
         internal override void Display()
         {
@@ -23,7 +23,7 @@ namespace Pulsar4X.Client
 
 
     //a do nothing helper class that is plugged into generics for static checks
-    public class SelectPrimaryBlankMenuHelper : PulsarGuiWindow
+    public class SelectPrimaryBlankMenuHelper : UniquePulsarGuiWindow<SelectPrimaryBlankMenuHelper>
     {
         internal override void Display()
         {

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/EntityWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/EntityWindow.cs
@@ -9,7 +9,7 @@ using Pulsar4X.Client.Interface.Widgets;
 
 namespace Pulsar4X.Client
 {
-    public class EntityWindow : NonUniquePulsarGuiWindow
+    public class EntityWindow : NamedPulsarGuiWindow
     {
         public int EntityId { get; }
         public string SystemId { get; }
@@ -35,7 +35,7 @@ namespace Pulsar4X.Client
         private float _animationProgress = 0f;
         private DateTime _animationStartTime;
 
-        public EntityWindow(int entityId, string systemId)
+        public EntityWindow(int entityId, string systemId) : base("EntityWindow|" + entityId)
         {
             EntityId = entityId;
             SystemId = systemId;

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/FireControlWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/FireControlWindow.cs
@@ -26,19 +26,15 @@ namespace Pulsar4X.Client
 
         public static FireControl GetInstance(EntityState orderEntity)
         {
-            FireControl thisitem;
-            if (!_uiState.LoadedWindows.ContainsKey(typeof(FireControl)))
+            if(!_uiState.TryGetUniqueWindow<FireControl>(out var window))
             {
-                thisitem = new FireControl();
+                window = _uiState.AddUniqueWindow(new FireControl());
             }
-            else
-            {
-                thisitem = (FireControl)_uiState.LoadedWindows[typeof(FireControl)];
-            }
-            if (orderEntity.StarSystemId != null)
-                thisitem.SetEntity(orderEntity.Id, orderEntity.StarSystemId);
 
-            return thisitem;
+            if (orderEntity.StarSystemId != null)
+                window.SetEntity(orderEntity.Id, orderEntity.StarSystemId);
+
+            return window;
         }
 
         public void SetEntity(int entityId, string systemId)

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/FireControlWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/FireControlWindow.cs
@@ -9,7 +9,7 @@ using Vector2 = System.Numerics.Vector2;
 namespace Pulsar4X.Client
 {
 
-    public class FireControl : PulsarGuiWindow
+    public class FireControl : UniquePulsarGuiWindow<FireControl>
     {
         private int? _entityId;
         private string? _systemId;

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/FleetWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/FleetWindow.cs
@@ -85,11 +85,12 @@ namespace Pulsar4X.Client
         }
         internal static FleetWindow GetInstance()
         {
-            if (!_uiState.LoadedWindows.ContainsKey(typeof(FleetWindow)))
+            if(_uiState.TryGetUniqueWindow<FleetWindow>(out var window))
             {
-                return new FleetWindow();
+                return window;
             }
-            return (FleetWindow)_uiState.LoadedWindows[typeof(FleetWindow)];
+
+            return _uiState.AddUniqueWindow(new FleetWindow());
         }
 
         private void FactionChanged(GlobalUIState uiState)

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/FleetWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/FleetWindow.cs
@@ -8,7 +8,7 @@ using Pulsar4X.Client.Interface.Widgets;
 
 namespace Pulsar4X.Client
 {
-    public class FleetWindow : PulsarGuiWindow
+    public class FleetWindow : UniquePulsarGuiWindow<FleetWindow>
     {
         private enum IssueOrderType
         {

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/GalaxyWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/GalaxyWindow.cs
@@ -17,16 +17,12 @@ namespace Pulsar4X.Client
 
         internal static GalaxyWindow GetInstance()
         {
-
-            GalaxyWindow thisItem;
-            if (!_uiState.LoadedWindows.ContainsKey(typeof(GalaxyWindow)))
+            if(_uiState.TryGetUniqueWindow<GalaxyWindow>(out var window))
             {
-                thisItem = new GalaxyWindow();
+                return window;
             }
-            thisItem = (GalaxyWindow)_uiState.LoadedWindows[typeof(GalaxyWindow)];
 
-            return thisItem;
-
+            return _uiState.AddUniqueWindow(new GalaxyWindow());
         }
 
         internal override void Display()

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/GalaxyWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/GalaxyWindow.cs
@@ -4,7 +4,7 @@ using Pulsar4X.Client.Interface.Widgets;
 
 namespace Pulsar4X.Client
 {
-    public class  GalaxyWindow : PulsarGuiWindow
+    public class  GalaxyWindow : UniquePulsarGuiWindow<GalaxyWindow>
     {
 
         private GalaxyWindow()

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/GameLogWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/GameLogWindow.cs
@@ -5,7 +5,7 @@ using Pulsar4X.Client.Interface.Widgets;
 
 namespace Pulsar4X.Client
 {
-    public class GameLogWindow : PulsarGuiWindow
+    public class GameLogWindow : UniquePulsarGuiWindow<GameLogWindow>
     {
         public HashSet<string> HidenEvents = new HashSet<string>();
 

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/GameLogWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/GameLogWindow.cs
@@ -15,11 +15,12 @@ namespace Pulsar4X.Client
 
         internal static GameLogWindow GetInstance()
         {
-            if (!_uiState.LoadedWindows.ContainsKey(typeof(GameLogWindow)))
+            if(_uiState.TryGetUniqueWindow<GameLogWindow>(out var window))
             {
-                return new GameLogWindow();
+                return window;
             }
-            return (GameLogWindow)_uiState.LoadedWindows[typeof(GameLogWindow)];
+
+            return _uiState.AddUniqueWindow(new GameLogWindow());
         }
 
         internal override void Display()

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/NamedPulsarGuiWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/NamedPulsarGuiWindow.cs
@@ -3,14 +3,32 @@ using System;
 
 namespace Pulsar4X.Client
 {
-    public abstract class NonUniquePulsarGuiWindow : UpdateWindowState
+    /// <summary>
+    /// A base class for GUI windows that have a unique name.
+    /// </summary>
+    public abstract class NamedPulsarGuiWindow : UpdateWindowState
     {
         protected ImGuiWindowFlags _flags = ImGuiWindowFlags.None;
-        internal bool CanActive = false;
-        internal bool IsActive = false;
-        internal string UniqueName = "test";
+        
+        internal bool CanActive { get; set; } = false;
+
+        private bool _isActive = false;
+        
+        public bool IsActive
+        {
+            get { return _isActive; }
+            set {  _isActive = value; }
+        }
+        protected ref bool IsActiveRef => ref _isActive;
+
+        internal string UniqueName { get; init; }
 
         protected EntityState? _lookedAtEntity;
+
+        protected NamedPulsarGuiWindow(string name)
+        {
+            UniqueName = name;
+        }
 
         public void SetActive(bool ActiveVal = true)
         {
@@ -27,11 +45,6 @@ namespace Pulsar4X.Client
             return IsActive;
         }
 
-        public void SetName(string Newname)
-        {
-            UniqueName = Newname;
-        }
-
         public virtual string GetName()
         {
             return UniqueName;
@@ -40,10 +53,6 @@ namespace Pulsar4X.Client
         public void StartDisplay()
         {
             _uiState.LoadedNonUniqueWindows[this.UniqueName] = this;
-        }
-
-        protected NonUniquePulsarGuiWindow()
-        {
         }
 
         internal abstract void Display();

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/NamedPulsarGuiWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/NamedPulsarGuiWindow.cs
@@ -64,13 +64,5 @@ namespace Pulsar4X.Client
         internal void Destroy()
         {
         }
-
-        public override void OnGameTickChange(DateTime newDate)
-        {
-        }
-
-        public override void OnSystemTickChange(DateTime newDate)
-        {
-        }
     }
 }

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/NavWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/NavWindow.cs
@@ -34,24 +34,21 @@ namespace Pulsar4X.Client
 
         public static NavWindow GetInstance(EntityState orderEntity)
         {
-            NavWindow thisitem;
-            if (!_uiState.LoadedWindows.ContainsKey(typeof(NavWindow)))
+            if(!_uiState.TryGetUniqueWindow<NavWindow>(out var window))
             {
-                thisitem = new NavWindow(orderEntity.Id, orderEntity.StarSystemId!);
-                thisitem.HardRefresh();
-            }
-            else
-            {
-                thisitem = (NavWindow)_uiState.LoadedWindows[typeof(NavWindow)];
-                if (thisitem._entityId != orderEntity.Id)
-                {
-                    thisitem._entityId = orderEntity.Id;
-                    thisitem._systemId = orderEntity.StarSystemId!;
-                    thisitem.HardRefresh();
-                }
+                window = _uiState.AddUniqueWindow(new NavWindow(orderEntity.Id, orderEntity.StarSystemId!));
+                window.HardRefresh();
+                return window;
             }
 
-            return thisitem;
+            if (window._entityId != orderEntity.Id)
+            {
+                window._entityId = orderEntity.Id;
+                window._systemId = orderEntity.StarSystemId!;
+                window.HardRefresh();
+            }
+
+            return window;
         }
 
         private void HardRefresh()

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/NavWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/NavWindow.cs
@@ -10,7 +10,7 @@ using Vector3 = Pulsar4X.Orbital.Vector3;
 
 namespace Pulsar4X.Client
 {
-    public class NavWindow : PulsarGuiWindow
+    public class NavWindow : UniquePulsarGuiWindow<NavWindow>
     {
         private int _entityId;
         private string _systemId = "";

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/NewtonOrderWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/NewtonOrderWindow.cs
@@ -8,7 +8,7 @@ using Vector3 = Pulsar4X.Orbital.Vector3;
 
 namespace Pulsar4X.Client
 {
-    public class ChangeCurrentOrbitWindow : PulsarGuiWindow
+    public class ChangeCurrentOrbitWindow : UniquePulsarGuiWindow<ChangeCurrentOrbitWindow>
     {
         int _entityId;
         string _systemId = "";

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/NewtonOrderWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/NewtonOrderWindow.cs
@@ -28,14 +28,17 @@ namespace Pulsar4X.Client
 
         internal static ChangeCurrentOrbitWindow GetInstance(EntityState entity)
         {
-            if (!_uiState.LoadedWindows.ContainsKey(typeof(ChangeCurrentOrbitWindow)))
+            if(!_uiState.TryGetUniqueWindow<ChangeCurrentOrbitWindow>(out var window))
             {
-                return new ChangeCurrentOrbitWindow(entity.Id, entity.StarSystemId!);
+                window = _uiState.AddUniqueWindow(new ChangeCurrentOrbitWindow(entity.Id, entity.StarSystemId!));
+                return window; // Entity is already set from ctor.
             }
-            var instance = (ChangeCurrentOrbitWindow)_uiState.LoadedWindows[typeof(ChangeCurrentOrbitWindow)];
-            if (instance._entityId != entity.Id || !instance.IsActive)
-                instance.OnEntityChange(entity.Id, entity.StarSystemId!);
-            return instance;
+
+            if (window._entityId != entity.Id || !window.IsActive)
+            {
+                window.OnEntityChange(entity.Id, entity.StarSystemId!);
+            }
+            return window;
         }
 
         void OnEntityChange(int entityId, string systemId)

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/OrdersListWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/OrdersListWindow.cs
@@ -5,15 +5,14 @@ using Pulsar4X.Client.Interface.Widgets;
 
 namespace Pulsar4X.Client
 {
-    public class OrdersListWindow : NonUniquePulsarGuiWindow
+    public class OrdersListWindow : NamedPulsarGuiWindow
     {
         private readonly int _entityId;
         private readonly string _systemId;
 
-        private OrdersListWindow(int entityId, string systemId, GlobalUIState state)
+        private OrdersListWindow(int entityId, string systemId, GlobalUIState state) : base("OrdersList|" + entityId)
         {
             _uiState = state;
-            SetName("OrdersList|" + entityId);
             _flags = ImGuiWindowFlags.None;
             _entityId = entityId;
             _systemId = systemId;
@@ -51,7 +50,7 @@ namespace Pulsar4X.Client
             string entityName = entity.GetView<NameView>()?.Name ?? "Unknown";
 
             ImGui.SetNextWindowSize(new System.Numerics.Vector2(550, 325), ImGuiCond.Once);
-            if (Window.Begin("Orders: " + entityName + "###" + UniqueName, ref IsActive, _flags))
+            if (Window.Begin("Orders: " + entityName + "###" + UniqueName, ref IsActiveRef, _flags))
             {
                 var tableFlags = ImGuiTableFlags.BordersInnerV | ImGuiTableFlags.RowBg | ImGuiTableFlags.Resizable | ImGuiTableFlags.SizingFixedFit;
                 if (ImGui.BeginTable("OrdersTable", 6, tableFlags))

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/PowerGenWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/PowerGenWindow.cs
@@ -13,20 +13,17 @@ namespace Pulsar4X.Client
 
         internal static PowerGenWindow GetInstance()
         {
-            PowerGenWindow instance;
-            if (!_uiState.LoadedWindows.ContainsKey(typeof(PowerGenWindow)))
+            if(!_uiState.TryGetUniqueWindow<PowerGenWindow>(out var window))
             {
-                instance = new PowerGenWindow();
-            }
-            else
-            {
-                instance = (PowerGenWindow)_uiState.LoadedWindows[typeof(PowerGenWindow)];
+                window = _uiState.AddUniqueWindow(new PowerGenWindow());
             }
 
             if (_uiState.LastClickedEntity is { } clicked && clicked.StarSystemId != null)
-                instance.SetEntity(clicked.Id, clicked.StarSystemId);
+            {
+                window.SetEntity(clicked.Id, clicked.StarSystemId);
+            }
 
-            return instance;
+            return window;
         }
 
         private PowerGenWindow()

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/PowerGenWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/PowerGenWindow.cs
@@ -5,7 +5,7 @@ using Vector2 = System.Numerics.Vector2;
 
 namespace Pulsar4X.Client
 {
-    public class PowerGenWindow : PulsarGuiWindow
+    public class PowerGenWindow : UniquePulsarGuiWindow<PowerGenWindow>
     {
         private int _entityId = -1;
         private string? _systemId;

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/RenameWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/RenameWindow.cs
@@ -3,7 +3,7 @@ using ImGuiNET;
 
 namespace Pulsar4X.Client
 {
-    public class RenameWindow : PulsarGuiWindow
+    public class RenameWindow : UniquePulsarGuiWindow<RenameWindow>
     {
         private int _targetEntityId = -1;
         private byte[]? _nameInputBuffer;

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/RenameWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/RenameWindow.cs
@@ -35,11 +35,12 @@ namespace Pulsar4X.Client
 
         internal static RenameWindow GetInstance()
         {
-            if (!_uiState.LoadedWindows.ContainsKey(typeof(RenameWindow)))
+            if(_uiState.TryGetUniqueWindow<RenameWindow>(out var window))
             {
-                return new RenameWindow();
+                return window;
             }
-            return (RenameWindow)_uiState.LoadedWindows[typeof(RenameWindow)];
+
+            return _uiState.AddUniqueWindow(new RenameWindow());
         }
 
         internal override void Display()

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/ResearchWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/ResearchWindow.cs
@@ -33,14 +33,12 @@ namespace Pulsar4X.Client
 
         internal static ResearchWindow GetInstance()
         {
-            ResearchWindow thisitem;
-            if (!_uiState.LoadedWindows.ContainsKey(typeof(ResearchWindow)))
+            if(_uiState.TryGetUniqueWindow<ResearchWindow>(out var window))
             {
-                thisitem = new ResearchWindow();
+                return window;
             }
-            thisitem = (ResearchWindow)_uiState.LoadedWindows[typeof(ResearchWindow)];
 
-            return thisitem;
+            return _uiState.AddUniqueWindow<ResearchWindow>(new ResearchWindow());
         }
 
         private void RefreshDerivedData(ResearchSnapshot research)

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/ResearchWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/ResearchWindow.cs
@@ -9,7 +9,7 @@ using Pulsar4X.Client.Interface.Widgets;
 
 namespace Pulsar4X.Client
 {
-    public class ResearchWindow : PulsarGuiWindow
+    public class ResearchWindow : UniquePulsarGuiWindow<ResearchWindow>
     {
         private readonly Vector2 invisButtonSize = new (15, 15);
 

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/SystemWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/SystemWindow.cs
@@ -11,17 +11,12 @@ public class SystemWindow : UniquePulsarGuiWindow<SystemWindow>
     private const string SystemViewPreferencesKey = "system-viewer";
 
     internal static SystemWindow GetInstance() {
-        SystemWindow thisItem;
-        if (!_uiState.LoadedWindows.ContainsKey(typeof(SystemWindow)))
+        if(_uiState.TryGetUniqueWindow<SystemWindow>(out var window))
         {
-            thisItem = new SystemWindow();
-        }
-        else
-        {
-            thisItem = (SystemWindow)_uiState.LoadedWindows[typeof(SystemWindow)];
+            return window;
         }
 
-        return thisItem;
+        return _uiState.AddUniqueWindow(new SystemWindow());
     }
 
     //displays selected entity info

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/SystemWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/SystemWindow.cs
@@ -6,7 +6,7 @@ using Pulsar4X.Client.Interface.Widgets;
 // Engine using: Stringify formatting helpers only.
 
 namespace Pulsar4X.Client;
-public class SystemWindow : PulsarGuiWindow
+public class SystemWindow : UniquePulsarGuiWindow<SystemWindow>
 {
     private const string SystemViewPreferencesKey = "system-viewer";
 

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/UniquePulsarGuiWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/UniquePulsarGuiWindow.cs
@@ -8,6 +8,7 @@ namespace Pulsar4X.Client
         protected ImGuiWindowFlags _flags = ImGuiWindowFlags.None;
         //internal bool IsLoaded;
         internal bool CanActive = true;
+
         protected bool IsActive = false;
         //internal int StateIndex = -1;
         //protected bool _IsOpen;
@@ -15,7 +16,8 @@ namespace Pulsar4X.Client
 
         protected UniquePulsarGuiWindow(string name)
         {
-            _uiState.LoadedWindows[this.GetType()] = this;
+            int x = 1;
+            // _uiState.LoadedWindows[this.GetType()] = this;
         }
 
         public void SetActive(bool ActiveVal = true)

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/UniquePulsarGuiWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/UniquePulsarGuiWindow.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Pulsar4X.Client
 {
-    public abstract class PulsarGuiWindow : UpdateWindowState
+    public abstract class UniquePulsarGuiWindow : UpdateWindowState
     {
         protected ImGuiWindowFlags _flags = ImGuiWindowFlags.None;
         //internal bool IsLoaded;
@@ -12,6 +12,11 @@ namespace Pulsar4X.Client
         //internal int StateIndex = -1;
         //protected bool _IsOpen;
         public bool ClickedEntityIsPrimary = true;
+
+        protected UniquePulsarGuiWindow(string name)
+        {
+            _uiState.LoadedWindows[this.GetType()] = this;
+        }
 
         public void SetActive(bool ActiveVal = true)
         {
@@ -34,12 +39,6 @@ namespace Pulsar4X.Client
         {
             return IsActive;
         }
-
-        protected PulsarGuiWindow()
-        {
-            _uiState.LoadedWindows[this.GetType()] = this;
-        }
-
 
         /*An example of how the constructor should be for a derived class.
          *
@@ -70,5 +69,15 @@ namespace Pulsar4X.Client
         public override void OnSystemTickChange(DateTime newDate)
         {
         }
+    }
+
+    /// <summary>
+    /// A generic version of <see cref="UniquePulsarGuiWindow"/> that automatically generates a unique name based on the type parameter <see cref="T"/>.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public abstract class UniquePulsarGuiWindow<T> : UniquePulsarGuiWindow
+    {
+        protected UniquePulsarGuiWindow() : base(typeof(T).FullName ?? typeof(T).Name)
+        {}
     }
 }

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/UniquePulsarGuiWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/UniquePulsarGuiWindow.cs
@@ -63,14 +63,6 @@ namespace Pulsar4X.Client
         internal virtual void EntityClicked(EntityState entity, MouseButtons button) { }
 
         internal virtual void EntitySelectedAsPrimary(EntityState entity) { }
-
-        public override void OnGameTickChange(DateTime newDate)
-        {
-        }
-
-        public override void OnSystemTickChange(DateTime newDate)
-        {
-        }
     }
 
     /// <summary>

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/WarpOrderWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/WarpOrderWindow.cs
@@ -12,7 +12,7 @@ namespace Pulsar4X.Client
     /// <summary>
     /// Orbit order window - this whole thing is a somewhat horrible state machine
     /// </summary>
-    public class WarpOrderWindow : PulsarGuiWindow// IOrderWindow
+    public class WarpOrderWindow : UniquePulsarGuiWindow<WarpOrderWindow> // IOrderWindow
     {
         int _entityId;
         string _systemId = "";

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/WarpOrderWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/WarpOrderWindow.cs
@@ -80,15 +80,9 @@ namespace Pulsar4X.Client
         {
             _flags = ImGuiWindowFlags.AlwaysAutoResize;
 
-            _entityId = entityId;
-            _systemId = systemId;
             _strictNewtonMode = _uiState.GameInfo?.StrictNewtonian ?? true;
             _departureDateTime = _uiState.PrimarySystemDateTime;
-            _displayText = "Warp Order: " + (OrderingEntity?.GetView<NameView>()?.Name ?? "Unknown");
-            _tooltipText = "Select target to orbit";
-            CurrentState = States.NeedsTarget;
-
-            CreateMoveWidget();
+            SetEntity(entityId, systemId);
 
             fsm = new Action[4, 4]
             {
@@ -108,22 +102,34 @@ namespace Pulsar4X.Client
             };
         }
 
+        internal void SetEntity(int entityId, string systemId)
+        {
+            _entityId = entityId;
+            _systemId = systemId;
+            _displayText = "Warp Order: " + (OrderingEntity?.GetView<NameView>()?.Name ?? "Unknown");
+            _tooltipText = "Select target to orbit";
+            CurrentState = States.NeedsTarget;
+            CreateMoveWidget();
+        }
+
         internal static WarpOrderWindow GetInstance(EntityState entity, bool SMMode = false)
         {
-            if (!_uiState.LoadedWindows.ContainsKey(typeof(WarpOrderWindow)))
+            if(!_uiState.TryGetUniqueWindow<WarpOrderWindow>(out var window))
             {
-                return new WarpOrderWindow(entity.Id, entity.StarSystemId!);
-            }
-            var instance = (WarpOrderWindow)_uiState.LoadedWindows[typeof(WarpOrderWindow)];
-            if (instance._entityId != entity.Id)
-            {
-                return new WarpOrderWindow(entity.Id, entity.StarSystemId!);
+                window = _uiState.AddUniqueWindow(new WarpOrderWindow(entity.Id, entity.StarSystemId!));
+                return window;  // Entity is set from ctor.
             }
 
-            instance.CurrentState = States.NeedsTarget;
-            instance._departureDateTime = _uiState.PrimarySystemDateTime;
-            instance.EntitySelected();
-            return instance;
+            // TODO: Probably needs more testing.
+            if(window._entityId != entity.Id)
+            {
+                window.SetEntity(entity.Id, entity.StarSystemId!);
+            }
+
+            window.CurrentState = States.NeedsTarget;
+            window._departureDateTime = _uiState.PrimarySystemDateTime;
+            window.EntitySelected();
+            return window;
         }
 
         #region Stuff that gets calculated when the state changes.

--- a/Pulsar4X/Pulsar4X.Client/Rendering/SystemMapRendering.cs
+++ b/Pulsar4X/Pulsar4X.Client/Rendering/SystemMapRendering.cs
@@ -484,11 +484,6 @@ namespace Pulsar4X.Client.Rendering
             return true;
         }
 
-        public override void OnGameTickChange(DateTime newDate)
-        {
-
-        }
-
         public override void OnSystemTickChange(DateTime newDate)
         {
             _state.PrimarySystemDateTime = newDate;

--- a/Pulsar4X/Pulsar4X.Client/State/GlobalUIState.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/GlobalUIState.cs
@@ -389,15 +389,13 @@ namespace Pulsar4X.Client
 
         internal T AddNamedWindow<T>(string name, T window) where T : NamedPulsarGuiWindow
         {
-            throw new NotImplementedException();
+            LoadedNonUniqueWindows.Add(name, window);
+            return window;
         }
 
         internal T AddUniqueWindow<T>(T window) where T : UniquePulsarGuiWindow
         {
-            if(!LoadedWindows.TryAdd(typeof(T), window))
-            {
-                throw new InvalidOperationException("Duplicate key in LoadedWindows: " + typeof(T).FullName);
-            }
+            LoadedWindows.Add(typeof(T), window);
             return window;
         }
 

--- a/Pulsar4X/Pulsar4X.Client/State/GlobalUIState.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/GlobalUIState.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using Pulsar4X.Api;
 using Pulsar4X.Input;
 using Pulsar4X.Client.Rendering;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Pulsar4X.Client
 {
@@ -326,6 +327,78 @@ namespace Pulsar4X.Client
                     Camera.MouseFrameIncrementY = e.Motion.Y;
                 }
             };
+        }
+
+        internal NamedPulsarGuiWindow? GetNamedWindow(string name)
+        {
+            if (TryGetNamedWindow(name, out var window))
+            {
+                return window;
+            }
+            return null;
+        }
+
+        internal bool TryGetNamedWindow(string name, [NotNullWhen(true)] out NamedPulsarGuiWindow? window)
+        {
+            if (LoadedNonUniqueWindows.TryGetValue(name, out var foundWindow))
+            {
+                window = foundWindow;
+                return true;
+            }
+
+            window = null;
+            return false;
+        }
+
+        internal bool TryGetNamedWindow<T>(string name, [NotNullWhen(true)] out T? window) where T : NamedPulsarGuiWindow
+        {
+            if (TryGetNamedWindow(name, out var foundWindow))
+            {
+                window = (T)foundWindow;
+                return true;
+            }
+            window = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Gets a unique window of type T. Only one instance of a unique window can exist at a time. 
+        /// </summary>
+        /// <typeparam name="T">The type of window.</typeparam>
+        /// <returns>The unique window instance, or <see langword="null"/> if no instance exists.</returns>
+        internal T? GetUniqueWindow<T>() where T : UniquePulsarGuiWindow
+        {
+            if(TryGetUniqueWindow<T>(out var window))
+            {
+                return window;
+            }
+            return null;
+        }
+
+        internal bool TryGetUniqueWindow<T>([NotNullWhen(true)]out T? window) where T : UniquePulsarGuiWindow
+        {
+            if (LoadedWindows.TryGetValue(typeof(T), out var foundWindow))
+            {
+                window = (T)foundWindow;
+                return true;
+            }
+
+            window = null;
+            return false;
+        }
+
+        internal T AddNamedWindow<T>(string name, T window) where T : NamedPulsarGuiWindow
+        {
+            throw new NotImplementedException();
+        }
+
+        internal T AddUniqueWindow<T>(T window) where T : UniquePulsarGuiWindow
+        {
+            if(!LoadedWindows.TryAdd(typeof(T), window))
+            {
+                throw new InvalidOperationException("Duplicate key in LoadedWindows: " + typeof(T).FullName);
+            }
+            return window;
         }
 
         private void DeactivateAllClosableWindows()

--- a/Pulsar4X/Pulsar4X.Client/State/GlobalUIState.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/GlobalUIState.cs
@@ -96,7 +96,7 @@ namespace Pulsar4X.Client
         internal bool ShowDemoWindow;
         internal IntPtr SDLRendererPtr { get; private set; }
         internal GalacticMapRender? GalacticMap;
-        internal List<UpdateWindowState> UpdateableWindows = new();
+        internal List<UpdateWindowState> UpdateableWindows { get; init; } = new();
         internal DateTime LastGameUpdateTime = new();
         internal DateTime SelectedSystemTime => GameClient?.Galaxy.GetSystem(SelectedStarSystemId)?.DateTime ?? default;
         internal DateTime SelectedSysLastUpdateTime = new();
@@ -107,9 +107,10 @@ namespace Pulsar4X.Client
         internal Camera Camera;
         internal SDL3Window ViewPort { get; private set; }
 
-        internal Dictionary<Type, PulsarGuiWindow> LoadedWindows = new();
-        internal Dictionary<String, NonUniquePulsarGuiWindow> LoadedNonUniqueWindows = new();
-        internal PulsarGuiWindow? ActiveWindow { get; set; }
+        internal Dictionary<Type, UniquePulsarGuiWindow> LoadedWindows { get; init; } = new();
+        internal Dictionary<string, NamedPulsarGuiWindow> LoadedNonUniqueWindows { get; init; } = new();
+
+        internal UniquePulsarGuiWindow? ActiveWindow { get; set; }
         internal List<List<UserOrbitSettings>> UserOrbitSettingsMtx = new();
         internal Dictionary<UserOrbitSettings.OrbitBodyType, float> DrawNameZoomLvl = new();
         internal Dictionary<string, IntPtr> SDLImageDictionary = new();
@@ -145,7 +146,7 @@ namespace Pulsar4X.Client
         internal GlobalUIState(SDL3Window viewport)
         {
             ViewPort = viewport;
-            PulsarGuiWindow._uiState = this;
+            UniquePulsarGuiWindow._uiState = this;
             var windowPtr = viewport.Window;
 
             SDLRendererPtr = SDL.CreateRenderer(windowPtr, "pulsar4x");

--- a/Pulsar4X/Pulsar4X.Client/State/UpdateWindowState.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/UpdateWindowState.cs
@@ -8,8 +8,8 @@ namespace Pulsar4X.Client
 
         public abstract bool GetActive();
 
-        public abstract void OnGameTickChange(DateTime newDate);
-        public abstract void OnSystemTickChange(DateTime newDate);
+        public virtual void OnGameTickChange(DateTime newDate) { }
+        public virtual void OnSystemTickChange(DateTime newDate) { }
 
         protected UpdateWindowState()
         {


### PR DESCRIPTION
## Summary

Restructures the main GUI abstract base classes into two categories `UniquePulsarGuiWindow` and `NamedPulsarGuiWindow`. Unique windows replace the old `PulsarGuiWindow`, while `NamedPulsarGuiWindow` replace the old `NonUniquePulsarGuiWindow`. The primary change is that the new classes do not self-register to `GlobalUIState` on construction, instead a new explicit API is provided to `GlobalUIState` for each of those window types for better control over registration.

## Rationale

Due to the way the old implementation handled registrations, a newly instantiated class could replace the old registration. This violates the principle of least surprise, as any instantiation could invalidate and replace registry objects. Additionally, the change is aimed to replace direct mutation to the UI state registries with a centralized API.

## Window types

The new architecture separates the windows into two types - `NamedWindow` and `UniqueWindow`. The primary distinction between the two is the number of instances of each derived window type that are supposed to be part of the registry.

- A named window can have multiple instances of itself in the registry as long as they have distinct names.
- A unique window **MUST** have only one instance in the registry. As such they can be identified by their class type.

#### Differences with old window types

The new abstract base classes do not enforce their uniqueness or automatically add themselves to the registry. They need to be explicitly added to the registry after construction, at which point their uniqueness is enforced.

#### Additional notes

In the exiting registry system for unique windows, the registry identifies them by their direct type information. A unique window can alternatively be identified by a unique name generated by their type. It may be beneficial to explore unifying the registry system to handle all windows as named windows, since they already enforce name uniqueness.

## Global UI state window API

To reduce the amount of boilerplate and direct access to the UI state registries two new APIs have been added to the state to manage the two types of windows. The two APIs will be called as `UniqueWindow` API and `NamedWindow` API respectively.

### Named Window API

The named window API is targeted to service `NamedPulsarGuiWindow` class derivatives. The API currently allows the addition of a window to the registry and querying the registry for a window with a specific name.

List of API methods:
- `AddNamedWindow<T>`
- `TryGetNamedWindow` / `TryGetNamedWindow<T>`
- `GetNamedWindow`

### Unique Window API

The unique window API is targeted service `UniquePulsarGuiWindow` class derivatives. As the classes are supposed to be unique in the registry, they are identified by their type. Due to this, the API only exposes generic versions of its methods.

List of API methods:
- `AddUniqueWindow<T>`
- `TryGetUniqueWindow<T>`
- `GetUniqueWindow<T>`

The primary use case of this API is to supersede code snippets such as these:
```csharp
ComponentsWindow instance;
if (!_uiState.LoadedWindows.ContainsKey(typeof(ComponentsWindow)))
{
    instance = new ComponentsWindow();
}
else
{
    instance = (ComponentsWindow)_uiState.LoadedWindows[typeof(ComponentsWindow)];
}
return instance;
```
with the cleaner
```csharp
if(_uiState.TryGetUniqueWindow<ComponentDesignWindow>(out var window))
{
    return window;
}

return _uiState.AddUniqueWindow(new ComponentDesignWindow());
```