### PR TITLE
Move InProcessAdapter and ClientGalaxy to the API project,

### DIFF
--- a/Pulsar4X/Pulsar4X.Api/ClientFactory.cs
+++ b/Pulsar4X/Pulsar4X.Api/ClientFactory.cs
@@ -1,0 +1,21 @@
+﻿using Pulsar4X.Api.Clients;
+
+namespace Pulsar4X.Api;
+
+/// <summary>
+/// A factory class for creating game clients that facilitate communication with the game servers.
+/// </summary>
+public static class ClientFactory
+{
+    /// <summary>
+    /// Creates a local client that connects to the given server instance.
+    /// 
+    /// This is beneficial for single-player games, where the client and server are in the same process.
+    /// </summary>
+    /// <param name="server">The server instance to connect to.</param>
+    /// <returns>A game client that communicates with the given server instance.</returns>
+    public static IGameClient CreateLocalClient(IGameServer server)
+    {
+        return new InProcessAdapter(server);
+    }
+}

--- a/Pulsar4X/Pulsar4X.Api/Clients/ClientGalaxy.cs
+++ b/Pulsar4X/Pulsar4X.Api/Clients/ClientGalaxy.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using Pulsar4X.Api;
-
-namespace Pulsar4X.Client;
+namespace Pulsar4X.Api.Clients;
 
 /// <summary>
 /// The default mutable <see cref="IClientGalaxy"/> maintained by an adapter. The UI reads it through

--- a/Pulsar4X/Pulsar4X.Api/Clients/InProcessAdapter.cs
+++ b/Pulsar4X/Pulsar4X.Api/Clients/InProcessAdapter.cs
@@ -1,10 +1,6 @@
-using System;
 using System.Collections.Concurrent;
-using System.Threading;
-using System.Threading.Tasks;
-using Pulsar4X.Api;
 
-namespace Pulsar4X.Client;
+namespace Pulsar4X.Api.Clients;
 
 /// <summary>
 /// Zero-copy in-process <see cref="IGameClient"/> for single-player / local games: forwards directly
@@ -25,7 +21,7 @@ public sealed class InProcessAdapter : IGameClient
     private readonly ConcurrentQueue<GameEventEnvelope> _inbound = new();
     private IDisposable? _subscription;
 
-    public InProcessAdapter(IGameServer server) => _server = server;
+    internal InProcessAdapter(IGameServer server) => _server = server;
 
     public PlayerSession Session { get; private set; } = PlayerSession.None;
     public bool IsConnected { get; private set; }

--- a/Pulsar4X/Pulsar4X.Client.Host/GameLifecycle.cs
+++ b/Pulsar4X/Pulsar4X.Client.Host/GameLifecycle.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using Pulsar4X.Api;
-using Pulsar4X.Client;
 using Pulsar4X.Colonies;
 using Pulsar4X.Engine.Api;
 using Pulsar4X.DataStructures;
@@ -264,7 +263,7 @@ public sealed class GameLifecycle : IGameLifecycle, IDesignDataProvider
         if (setAsPlayer)
             _playerFaction = faction;
 
-        var client = new InProcessAdapter(_server);
+        var client = ClientFactory.CreateLocalClient(_server);
         // The trusted host presents the SM credential so it can bind to the GameMaster for SM mode.
         string? credential = faction == _game?.GameMasterFaction ? ConnectRequest.SpaceMasterCredential : null;
         var connect = client.ConnectAsync(new ConnectRequest { PlayerName = "Player", FactionId = faction.Id, Credential = credential }).Result;


### PR DESCRIPTION
The PR moves the `InProcessAdapter` and `ClientGalaxy` implementations to `Pulsar4X.Api` project.

The aim of this is to remove the connection client implementation from the UI layer (currently `Pulsar4X.Client`). This way the adapters themselves are reusable, regardless of the UI frontend. It also removes the possibility of the UI layer to depend on adapter specific functionality.

### Creating an adapter

The change reduces the accessibility of `InProcessAdapter`'s constructor to `internal`. As it now lives in a different assembly, it can no longer be constructed directly. To allow frontends to construct a client a new static class `ClientFactory` is added.

The client factory currently exposes a method `CreateLocalClient(IGameServer server)` to which wires up a `IGameServer` instance to an appropriate `IGameClient`. In the future it can be extended with additional methods like `CreateRemoteClient(ip, port)` for connecting to remote clients. The factory method can be especially useful for connecting to a remote server asynchronously, as regular constructors cannot support async state machine.

