### PR TITLE
Minor cleanup of colony management UI code.

### DIFF
--- a/Pulsar4X/Pulsar4X.Client/Interface/Displays/ColonyConstructionDisplay.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Displays/ColonyConstructionDisplay.cs
@@ -10,16 +10,9 @@ namespace Pulsar4X.Client
     /// </summary>
     public sealed class ColonyConstructionDisplay
     {
-        private static ColonyConstructionDisplay? instance = null;
-
         private int _selectedDesignIndex = -1;
 
-        private ColonyConstructionDisplay() { }
-
-        internal static ColonyConstructionDisplay GetInstance()
-        {
-            return instance ??= new ColonyConstructionDisplay();
-        }
+        internal ColonyConstructionDisplay() { }
 
         public void Display(int entityId, ConstructionView? construction, GlobalUIState uiState)
         {

--- a/Pulsar4X/Pulsar4X.Client/Interface/Displays/ColonyProductionDisplay.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Displays/ColonyProductionDisplay.cs
@@ -11,20 +11,13 @@ namespace Pulsar4X.Client
     /// </summary>
     public sealed class ColonyProductionDisplay
     {
-        private static ColonyProductionDisplay? instance = null;
-
         private string? _selectedProdLine;
         private int _newJobDesignIndex = 0;
         private int _newJobBatchCount = 1;
         private bool _newJobRepeat = false;
         private bool _newJobAutoInstall = true;
 
-        private ColonyProductionDisplay() { }
-
-        internal static ColonyProductionDisplay GetInstance()
-        {
-            return instance ??= new ColonyProductionDisplay();
-        }
+        internal ColonyProductionDisplay() { }
 
         public void Display(int entityId, IndustryView? industry, GlobalUIState uiState)
         {

--- a/Pulsar4X/Pulsar4X.Client/Interface/Displays/ColonyProductionDisplay.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Displays/ColonyProductionDisplay.cs
@@ -86,10 +86,13 @@ namespace Pulsar4X.Client
                         }
 
                         ImGui.SameLine();
+
+                        ImGui.BeginDisabled();
                         if (ImGui.Button("Upgrade " + line.Name))
                         {
                             // TODO: add upgrade functionality
                         }
+                        ImGui.EndDisabled();
 
                         if (line.Jobs.Count > 0)
                         {

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/ColonyManagementWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/ColonyManagementWindow.cs
@@ -17,6 +17,9 @@ namespace Pulsar4X.Client
         public int? SelectedColonyId { get; private set; } = null;
         private string? _selectedSystemId = null;
 
+        private ColonyProductionDisplay? _productionDisplay;
+        private ColonyConstructionDisplay? _constructionDisplay;
+
         internal static ColonyManagementWindow GetInstance()
         {
             if(_uiState.TryGetUniqueWindow<ColonyManagementWindow>(out var window))
@@ -85,50 +88,51 @@ namespace Pulsar4X.Client
                 var selectedSystem = _selectedSystemId == null ? null : galaxy.GetSystem(_selectedSystemId);
                 var selectedColony = SelectedColonyId is { } id ? selectedSystem?.GetEntity(id) : null;
 
-                if (selectedColony == null || selectedSystem == null)
+                if (selectedColony != null && selectedSystem != null)
                 {
-                    Window.End();
-                    return;
+                    ImGui.SameLine();
+                    DisplaySelectedColony(selectedSystem, selectedColony);
                 }
-
-                ImGui.SameLine();
-
-                if(ImGui.BeginChild("ColoniesTabs"))
-                {
-                    ImGui.BeginTabBar("EconomicsTabBar", ImGuiTabBarFlags.None);
-
-                    if(ImGui.BeginTabItem("Summary"))
-                    {
-                        DisplaySummary(selectedColony, selectedSystem);
-                        ImGui.EndTabItem();
-                    }
-                    if(ImGui.BeginTabItem("Production"))
-                    {
-                        ColonyProductionDisplay.GetInstance()
-                            .Display(selectedColony.Id, selectedColony.GetView<IndustryView>(), _uiState);
-                        ImGui.EndTabItem();
-                    }
-                    if(ImGui.BeginTabItem("Construction"))
-                    {
-                        ColonyConstructionDisplay.GetInstance()
-                            .Display(selectedColony.Id, selectedColony.GetView<ConstructionView>(), _uiState);
-                        ImGui.EndTabItem();
-                    }
-                    if(selectedColony.GetView<ColonyMiningView>() is { } mining && ImGui.BeginTabItem("Mining"))
-                    {
-                        mining.Display();
-                        ImGui.EndTabItem();
-                    }
-                    if(selectedColony.GetView<NavalAcademyView>() is { } academy && ImGui.BeginTabItem("Naval Academy"))
-                    {
-                        DisplayNavalAcademy(selectedColony.Id, academy);
-                        ImGui.EndTabItem();
-                    }
-                    ImGui.EndTabBar();
-                }
-                ImGui.EndChild();
             }
             Window.End();
+        }
+
+        private void DisplaySelectedColony(IClientSystem selectedSystem, EntitySnapshot selectedColony)
+        {
+            if (ImGui.BeginChild("ColoniesTabs"))
+            {
+                ImGui.BeginTabBar("EconomicsTabBar", ImGuiTabBarFlags.None);
+
+                if (ImGui.BeginTabItem("Summary"))
+                {
+                    DisplaySummary(selectedColony, selectedSystem);
+                    ImGui.EndTabItem();
+                }
+                if (ImGui.BeginTabItem("Production"))
+                {
+                    _productionDisplay ??= new ColonyProductionDisplay();
+                    _productionDisplay.Display(selectedColony.Id, selectedColony.GetView<IndustryView>(), _uiState);
+                    ImGui.EndTabItem();
+                }
+                if (ImGui.BeginTabItem("Construction"))
+                {
+                    _constructionDisplay ??= new ColonyConstructionDisplay();
+                    _constructionDisplay.Display(selectedColony.Id, selectedColony.GetView<ConstructionView>(), _uiState);
+                    ImGui.EndTabItem();
+                }
+                if (selectedColony.GetView<ColonyMiningView>() is { } mining && ImGui.BeginTabItem("Mining"))
+                {
+                    mining.Display();
+                    ImGui.EndTabItem();
+                }
+                if (selectedColony.GetView<NavalAcademyView>() is { } academy && ImGui.BeginTabItem("Naval Academy"))
+                {
+                    DisplayNavalAcademy(selectedColony.Id, academy);
+                    ImGui.EndTabItem();
+                }
+                ImGui.EndTabBar();
+            }
+            ImGui.EndChild();
         }
 
         private void DisplaySummary(EntitySnapshot colony, IClientSystem system)


### PR DESCRIPTION
#### Changes
 - Changed `ColonyProductionDisplay` and `ColonyConstructionDisplay` converted to instanced objects. 
This ties them to the lifetime of `ColonyManagementWindow` which means they are unloaded when the window is unloaded.
- Added `DisplaySelectedColony` helper method to `ColonyManagementWindow`.
This removes the need for the early return `Window.End()` `if` branch inside the `ColonyManagementWindow.Display()`.
- Added a `Disabled` scope over `Upgrade XXX` button as it is a placeholder.


