### PR TITLE
Extract `WindowManager` class from `GlobalUIState`

### DIFF
--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/EntityUIWindows.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/EntityUIWindows.cs
@@ -156,8 +156,7 @@ namespace Pulsar4X.Client
                 }
                 else if (T == typeof(OrdersListWindow))
                 {
-                    var instance = OrdersListWindow.GetInstance(_entityState);
-                    instance.ToggleActive();
+                    _state.WindowManager.ActivateOrderListWindow(_entityState);
                 }
             }
         }

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/EntityUIWindows.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/EntityUIWindows.cs
@@ -32,7 +32,7 @@ namespace Pulsar4X.Client
     }
 
     //has all initialization rutines for common entity management related UI windows, also has a function that checks if a window can be opened for a given EntityState
-    public class EntityUIWindows
+    public static class EntityUIWindows
     {
         /// <summary>The clicked entity's faction-scoped snapshot. The views the server projected
         /// for this faction gate which actions make sense (and visibility/ownership rules are
@@ -156,7 +156,7 @@ namespace Pulsar4X.Client
                 }
                 else if (T == typeof(OrdersListWindow))
                 {
-                    var instance = OrdersListWindow.GetInstance(_entityState, _state);
+                    var instance = OrdersListWindow.GetInstance(_entityState);
                     instance.ToggleActive();
                 }
             }
@@ -164,22 +164,37 @@ namespace Pulsar4X.Client
 
         public static bool CheckOpenUIWindow(Type T, EntityState _entityState, GlobalUIState _state)
         {
-            //If the user has requested a menu be opened and if
-            bool returnval;
-
             // Global Windows
-            if (T == typeof(WarpOrderWindow)) returnval = WarpOrderWindow.GetInstance(_entityState).GetActive();
-            else if (T == typeof(ChangeCurrentOrbitWindow)) returnval = ChangeCurrentOrbitWindow.GetInstance(_entityState).GetActive();
-            else if (T == typeof(FireControl)) returnval = FireControl.GetInstance(_entityState).GetActive();
-            else if (T == typeof(NavWindow)) returnval = NavWindow.GetInstance(_entityState).GetActive();
-            else if (T == typeof(CreateTransferWindow)) returnval = CreateTransferWindow.GetInstance().GetActive();
-            else if (T == typeof(PowerGenWindow)) returnval = PowerGenWindow.GetInstance().GetActive();
+            if (T == typeof(WarpOrderWindow))
+            {
+                return WarpOrderWindow.GetInstance(_entityState).GetActive();
+            }
+            else if (T == typeof(ChangeCurrentOrbitWindow))
+            {
+                return ChangeCurrentOrbitWindow.GetInstance(_entityState).GetActive();
+            }
+            else if (T == typeof(FireControl))
+            {
+                return FireControl.GetInstance(_entityState).GetActive();
+            }
+            else if (T == typeof(NavWindow))
+            {
+                return NavWindow.GetInstance(_entityState).GetActive();
+            }
+            else if (T == typeof(CreateTransferWindow))
+            {
+                return CreateTransferWindow.GetInstance().GetActive();
+            }
+            else if (T == typeof(PowerGenWindow))
+            {
+                return PowerGenWindow.GetInstance().GetActive();
+            }
             // Instance Windows
-            else if (T == typeof(OrdersListWindow)) returnval = OrdersListWindow.GetInstance(_entityState, _state).GetActive();
-            else returnval = false;
-            return returnval;
-
-
+            else if (T == typeof(OrdersListWindow))
+            {
+                return OrdersListWindow.GetInstance(_entityState).GetActive();
+            }
+            else return false;
         }
     }
 

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/EntityUIWindows.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/EntityUIWindows.cs
@@ -115,7 +115,7 @@ namespace Pulsar4X.Client
                     ChangeCurrentOrbitWindow.GetInstance(_entityState).ToggleActive();
                     _state.ActiveWindow = ChangeCurrentOrbitWindow.GetInstance(_entityState);
                 }
-                //Menu is ficrecontrol menu
+                //Menu is fire control menu
                 else if (T == typeof(FireControl))
                 {
                     var instance = FireControl.GetInstance(_entityState);

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/NamedPulsarGuiWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/NamedPulsarGuiWindow.cs
@@ -50,11 +50,6 @@ namespace Pulsar4X.Client
             return UniqueName;
         }
 
-        public void StartDisplay()
-        {
-            _uiState.LoadedNonUniqueWindows[this.UniqueName] = this;
-        }
-
         internal abstract void Display();
 
         internal virtual void EntityClicked(EntityState entity, MouseButtons button) { }

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/OrdersListWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/OrdersListWindow.cs
@@ -10,21 +10,20 @@ namespace Pulsar4X.Client
         private readonly int _entityId;
         private readonly string _systemId;
 
-        private OrdersListWindow(int entityId, string systemId, GlobalUIState state) : base("OrdersList|" + entityId)
+        private OrdersListWindow(int entityId, string systemId) : base("OrdersList|" + entityId)
         {
-            _uiState = state;
             _flags = ImGuiWindowFlags.None;
             _entityId = entityId;
             _systemId = systemId;
         }
 
-        internal static OrdersListWindow GetInstance(EntityState entity, GlobalUIState state)
+        internal static OrdersListWindow GetInstance(EntityState entity)
         {
             var winManager = _uiState.WindowManager;
             string name = "OrdersList|" + entity.Id.ToString();
             if (!winManager.TryGetNamedWindow(name, out OrdersListWindow? orderList))
             {
-                orderList = new OrdersListWindow(entity.Id, entity.StarSystemId!, state);
+                orderList = new OrdersListWindow(entity.Id, entity.StarSystemId!);
                 winManager.AddNamedWindow(name, orderList);
             }
 

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/OrdersListWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/OrdersListWindow.cs
@@ -5,16 +5,83 @@ using Pulsar4X.Client.Interface.Widgets;
 
 namespace Pulsar4X.Client
 {
+    internal static class OrderWindowExtensions
+    {
+        private static int _idCounter = 0;
+
+        /// <summary>
+        /// Activates a window displaying the orders for a given entity.
+        /// </summary>
+        /// <param name="manager">The window manager instance.</param>
+        /// <param name="entity">The entity requested for display.</param>
+        public static OrdersListWindow ActivateOrderListWindow(this WindowManager manager, EntityState entity)
+        {
+            if(manager.NamedWindowsByType.TryGetValue(typeof(OrdersListWindow), out var windowList))
+            {
+                // Reuse an existing inactive window if available
+                foreach (var window in windowList.Cast<OrdersListWindow>().Where(w => !w.GetActive()))
+                {
+                    window.SetEntity(entity);
+                    window.SetActive(true);
+                    return window;
+                }
+            }
+
+            string name = MakeName();
+            var orderList = new OrdersListWindow(name, entity.Id, entity.StarSystemId!);
+            manager.AddNamedWindow(name, orderList);
+            orderList.SetActive(true);
+
+            return orderList;
+        }
+
+        /// <summary>
+        /// Checks if there is an active orders window for a given entity.
+        /// </summary>
+        /// <param name="manager">The window manager instance.</param>
+        /// <param name="entity">The entity to check for an active orders window.</param>
+        /// <returns>True if there is an active orders window for the given entity; otherwise, false.</returns>
+        public static bool HasActiveOrdersWindow(this WindowManager manager, EntityState entity)
+        {
+            if(manager.NamedWindowsByType.TryGetValue(typeof(OrdersListWindow), out var windowList))
+            {
+                foreach (var window in windowList.Cast<OrdersListWindow>())
+                {
+                    if (window.GetActive() && window.EntityId == entity.Id && window.SystemId == entity.StarSystemId)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private static string MakeName()
+        {
+            return "OrdersList|" + _idCounter++;
+        }
+    }
+
     public class OrdersListWindow : NamedPulsarGuiWindow
     {
-        private readonly int _entityId;
-        private readonly string _systemId;
+        private int _entityId;
+        private string _systemId;
 
-        private OrdersListWindow(int entityId, string systemId) : base("OrdersList|" + entityId)
+        internal int EntityId => _entityId;
+        internal string SystemId => _systemId;
+
+        internal OrdersListWindow(string windowName, int entityId, string systemId) : base(windowName)
         {
             _flags = ImGuiWindowFlags.None;
             _entityId = entityId;
             _systemId = systemId;
+        }
+
+        internal void SetEntity(EntityState entity)
+        {
+            _entityId = entity.Id;
+            _systemId = entity.StarSystemId!;
         }
 
         internal static OrdersListWindow GetInstance(EntityState entity)
@@ -23,7 +90,7 @@ namespace Pulsar4X.Client
             string name = "OrdersList|" + entity.Id.ToString();
             if (!winManager.TryGetNamedWindow(name, out OrdersListWindow? orderList))
             {
-                orderList = new OrdersListWindow(entity.Id, entity.StarSystemId!);
+                orderList = new OrdersListWindow(name, entity.Id, entity.StarSystemId!);
                 winManager.AddNamedWindow(name, orderList);
             }
 

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/OrdersListWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/OrdersListWindow.cs
@@ -20,19 +20,15 @@ namespace Pulsar4X.Client
 
         internal static OrdersListWindow GetInstance(EntityState entity, GlobalUIState state)
         {
+            var winManager = _uiState.WindowManager;
             string name = "OrdersList|" + entity.Id.ToString();
-            OrdersListWindow thisItem;
-            if (!_uiState.LoadedNonUniqueWindows.ContainsKey(name))
+            if (!winManager.TryGetNamedWindow(name, out OrdersListWindow? orderList))
             {
-                thisItem = new OrdersListWindow(entity.Id, entity.StarSystemId!, state);
-                thisItem.StartDisplay();
-            }
-            else
-            {
-                thisItem = (OrdersListWindow)_uiState.LoadedNonUniqueWindows[name];
+                orderList = new OrdersListWindow(entity.Id, entity.StarSystemId!, state);
+                winManager.AddNamedWindow(name, orderList);
             }
 
-            return thisItem;
+            return orderList;
         }
 
         internal override void Display()

--- a/Pulsar4X/Pulsar4X.Client/PulsarMainWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/PulsarMainWindow.cs
@@ -183,28 +183,6 @@ namespace Pulsar4X.Client
         public override void Update()
         {
             base.Update();
-
-            // Apply any server updates received since last frame as one atomic batch on this (UI)
-            // thread, before any window reads the galaxy model this frame.
-            _state.GameClient?.Update();
-
-            //update and refresh state for GameDateTimechange
-            if(_state.GameClient is { } gameClient)
-            {
-                //update and refresh state for SystemDateTimechage
-                var curTime = _state.SelectedSystemTime;
-                if (curTime != _state.SelectedSysLastUpdateTime)
-                {
-                    foreach (var item in _state.UpdateableWindows)
-                    {
-                        if (item.GetActive() == true)
-                            item.OnSystemTickChange(curTime);
-                    }
-
-                    _state.SelectedSysLastUpdateTime = curTime;
-                }
-            }
-
             _state.Update();
         }
 

--- a/Pulsar4X/Pulsar4X.Client/PulsarMainWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/PulsarMainWindow.cs
@@ -247,19 +247,11 @@ namespace Pulsar4X.Client
             _state.GalacticMap?.DrawNameIcons();
 
             // Render any windows that have registered themselves
-            foreach (var item in _state.LoadedWindows.Values.ToArray())
-            {
-                item.Display();
-            }
+            _state.WindowManager.RenderActiveWindows();
 
             foreach (var entityWindow in _state.EntityWindows.Values.ToArray())
             {
                 entityWindow.Display();
-            }
-
-            foreach (var item in _state.LoadedNonUniqueWindows.Values.ToArray())
-            {
-                item.Display();
             }
 
             // Render the maneuver node panel overlay (if active)

--- a/Pulsar4X/Pulsar4X.Client/Rendering/GalacticMapRender.cs
+++ b/Pulsar4X/Pulsar4X.Client/Rendering/GalacticMapRender.cs
@@ -69,7 +69,7 @@ namespace Pulsar4X.Client
 
                 if (!RenderedMaps.ContainsKey(systemId))
                 {
-                    SystemMapRendering map = new SystemMapRendering(_window, _state);
+                    var map = _state.WindowManager.AddWindow(new SystemMapRendering(_window, _state));
                     map.Initialize(systemId);
                     RenderedMaps[systemId] = map;
                     map.GalacticMapPosition.X = x;

--- a/Pulsar4X/Pulsar4X.Client/State/GlobalUIState.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/GlobalUIState.cs
@@ -822,6 +822,7 @@ namespace Pulsar4X.Client
                 if (!EntityWindows.TryGetValue(entityGuid, out EntityWindow? value))
                 {
                     value = new EntityWindow(entityGuid, starSys);
+                    WindowManager.AddWindow(value);
                     EntityWindows.Add(entityGuid, value);
                 }
 

--- a/Pulsar4X/Pulsar4X.Client/State/GlobalUIState.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/GlobalUIState.cs
@@ -112,11 +112,11 @@ namespace Pulsar4X.Client
         [Obsolete("Use WindowManager.AllWindows instead", DiagnosticId = "P4X0001")]
         internal List<UpdateWindowState> UpdateableWindows => WindowManager.AllWindows;
         
-        [Obsolete("Use WindowManager.LoadedWindows instead", DiagnosticId = "P4X0001")]
-        internal Dictionary<Type, UniquePulsarGuiWindow> LoadedWindows => WindowManager.LoadedWindows;
+        [Obsolete("Use WindowManager.UniqueWindows instead", DiagnosticId = "P4X0001")]
+        internal Dictionary<Type, UniquePulsarGuiWindow> LoadedWindows => WindowManager.UniqueWindows;
         
-        [Obsolete("Use WindowManager.LoadedNonUniqueWindows instead", DiagnosticId = "P4X0001")]
-        internal Dictionary<string, NamedPulsarGuiWindow> LoadedNonUniqueWindows => WindowManager.LoadedNonUniqueWindows;
+        [Obsolete("Use WindowManager.NamedWindows instead", DiagnosticId = "P4X0001")]
+        internal Dictionary<string, NamedPulsarGuiWindow> LoadedNonUniqueWindows => WindowManager.NamedWindows;
 
         internal UniquePulsarGuiWindow? ActiveWindow { get; set; }
         internal List<List<UserOrbitSettings>> UserOrbitSettingsMtx = new();
@@ -356,14 +356,6 @@ namespace Pulsar4X.Client
         internal T AddNamedWindow<T>(string name, T window) where T : NamedPulsarGuiWindow => WindowManager.AddNamedWindow(name, window);
         [Obsolete("Use WindowManager directly", DiagnosticId = "P4X0001")]
         internal T AddUniqueWindow<T>(T window) where T : UniquePulsarGuiWindow => WindowManager.AddUniqueWindow(window);
-
-        private void DeactivateAllClosableWindows()
-        {
-            foreach (var window in LoadedWindows)
-            {
-                window.Value.SetActive(false);
-            }
-        }
 
         /// <summary>
         /// Clears all cached UI state to prepare for a new game.

--- a/Pulsar4X/Pulsar4X.Client/State/GlobalUIState.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/GlobalUIState.cs
@@ -1,13 +1,13 @@
 ﻿using ImGuiNET;
+using Pulsar4X.Api;
+using Pulsar4X.Client.Rendering;
+using Pulsar4X.Input;
 using Pulsar4X.Orbital;
 using SDL3;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using Pulsar4X.Api;
-using Pulsar4X.Input;
-using Pulsar4X.Client.Rendering;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 
 namespace Pulsar4X.Client
 {
@@ -97,7 +97,6 @@ namespace Pulsar4X.Client
         internal bool ShowDemoWindow;
         internal IntPtr SDLRendererPtr { get; private set; }
         internal GalacticMapRender? GalacticMap;
-        internal List<UpdateWindowState> UpdateableWindows { get; init; } = new();
         internal DateTime LastGameUpdateTime = new();
         internal DateTime SelectedSystemTime => GameClient?.Galaxy.GetSystem(SelectedStarSystemId)?.DateTime ?? default;
         internal DateTime SelectedSysLastUpdateTime = new();
@@ -108,8 +107,16 @@ namespace Pulsar4X.Client
         internal Camera Camera;
         internal SDL3Window ViewPort { get; private set; }
 
-        internal Dictionary<Type, UniquePulsarGuiWindow> LoadedWindows { get; init; } = new();
-        internal Dictionary<string, NamedPulsarGuiWindow> LoadedNonUniqueWindows { get; init; } = new();
+        internal WindowManager WindowManager { get; init; } = new();
+
+        [Obsolete("Use WindowManager.AllWindows instead", DiagnosticId = "P4X0001")]
+        internal List<UpdateWindowState> UpdateableWindows => WindowManager.AllWindows;
+        
+        [Obsolete("Use WindowManager.LoadedWindows instead", DiagnosticId = "P4X0001")]
+        internal Dictionary<Type, UniquePulsarGuiWindow> LoadedWindows => WindowManager.LoadedWindows;
+        
+        [Obsolete("Use WindowManager.LoadedNonUniqueWindows instead", DiagnosticId = "P4X0001")]
+        internal Dictionary<string, NamedPulsarGuiWindow> LoadedNonUniqueWindows => WindowManager.LoadedNonUniqueWindows;
 
         internal UniquePulsarGuiWindow? ActiveWindow { get; set; }
         internal List<List<UserOrbitSettings>> UserOrbitSettingsMtx = new();
@@ -329,75 +336,26 @@ namespace Pulsar4X.Client
             };
         }
 
-        internal NamedPulsarGuiWindow? GetNamedWindow(string name)
-        {
-            if (TryGetNamedWindow(name, out var window))
-            {
-                return window;
-            }
-            return null;
-        }
-
-        internal bool TryGetNamedWindow(string name, [NotNullWhen(true)] out NamedPulsarGuiWindow? window)
-        {
-            if (LoadedNonUniqueWindows.TryGetValue(name, out var foundWindow))
-            {
-                window = foundWindow;
-                return true;
-            }
-
-            window = null;
-            return false;
-        }
-
-        internal bool TryGetNamedWindow<T>(string name, [NotNullWhen(true)] out T? window) where T : NamedPulsarGuiWindow
-        {
-            if (TryGetNamedWindow(name, out var foundWindow))
-            {
-                window = (T)foundWindow;
-                return true;
-            }
-            window = null;
-            return false;
-        }
+        [Obsolete("Use WindowManager directly", DiagnosticId = "P4X0001")]
+        internal NamedPulsarGuiWindow? GetNamedWindow(string name) => GetNamedWindow(name);
+        [Obsolete("Use WindowManager directly", DiagnosticId = "P4X0001")]
+        internal bool TryGetNamedWindow(string name, [NotNullWhen(true)] out NamedPulsarGuiWindow? window) => TryGetNamedWindow(name, out window);
+        [Obsolete("Use WindowManager directly", DiagnosticId = "P4X0001")]
+        internal bool TryGetNamedWindow<T>(string name, [NotNullWhen(true)] out T? window) where T : NamedPulsarGuiWindow => TryGetNamedWindow(name, out window);
 
         /// <summary>
         /// Gets a unique window of type T. Only one instance of a unique window can exist at a time. 
         /// </summary>
         /// <typeparam name="T">The type of window.</typeparam>
         /// <returns>The unique window instance, or <see langword="null"/> if no instance exists.</returns>
-        internal T? GetUniqueWindow<T>() where T : UniquePulsarGuiWindow
-        {
-            if(TryGetUniqueWindow<T>(out var window))
-            {
-                return window;
-            }
-            return null;
-        }
-
-        internal bool TryGetUniqueWindow<T>([NotNullWhen(true)]out T? window) where T : UniquePulsarGuiWindow
-        {
-            if (LoadedWindows.TryGetValue(typeof(T), out var foundWindow))
-            {
-                window = (T)foundWindow;
-                return true;
-            }
-
-            window = null;
-            return false;
-        }
-
-        internal T AddNamedWindow<T>(string name, T window) where T : NamedPulsarGuiWindow
-        {
-            LoadedNonUniqueWindows.Add(name, window);
-            return window;
-        }
-
-        internal T AddUniqueWindow<T>(T window) where T : UniquePulsarGuiWindow
-        {
-            LoadedWindows.Add(typeof(T), window);
-            return window;
-        }
+        [Obsolete("Use WindowManager directly", DiagnosticId = "P4X0001")]
+        internal T? GetUniqueWindow<T>() where T : UniquePulsarGuiWindow => WindowManager.GetUniqueWindow<T>();
+        [Obsolete("Use WindowManager directly", DiagnosticId = "P4X0001")]
+        internal bool TryGetUniqueWindow<T>([NotNullWhen(true)]out T? window) where T : UniquePulsarGuiWindow => WindowManager.TryGetUniqueWindow<T>(out window);
+        [Obsolete("Use WindowManager directly", DiagnosticId = "P4X0001")]
+        internal T AddNamedWindow<T>(string name, T window) where T : NamedPulsarGuiWindow => WindowManager.AddNamedWindow(name, window);
+        [Obsolete("Use WindowManager directly", DiagnosticId = "P4X0001")]
+        internal T AddUniqueWindow<T>(T window) where T : UniquePulsarGuiWindow => WindowManager.AddUniqueWindow(window);
 
         private void DeactivateAllClosableWindows()
         {
@@ -417,8 +375,7 @@ namespace Pulsar4X.Client
             GameClient?.DisconnectAsync();
             GameClient = null;
             GameInfo = null;
-            LoadedWindows.Clear();
-            LoadedNonUniqueWindows.Clear();
+            WindowManager.UnloadAllWindows();
             EntityWindows.Clear();
             _savedCameraStates.Clear();
             LastClickedEntity = null;
@@ -435,6 +392,26 @@ namespace Pulsar4X.Client
         /// </summary>
         internal void Update()
         {
+            // Apply any server updates received since last frame as one atomic batch on this (UI)
+            // thread, before any window reads the galaxy model this frame.
+            GameClient?.Update();
+
+            //update and refresh state for GameDateTimechange
+            if (GameClient is not null)
+            {
+                //update and refresh state for SystemDateTimechage
+                var curTime = SelectedSystemTime;
+                if (curTime != SelectedSysLastUpdateTime)
+                {
+                    foreach (var item in WindowManager.GetActiveWindows())
+                    {
+                        item.OnSystemTickChange(curTime);
+                    }
+
+                    SelectedSysLastUpdateTime = curTime;
+                }
+            }
+
             GalacticMap?.Update();
         }
 

--- a/Pulsar4X/Pulsar4X.Client/State/GlobalUIState.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/GlobalUIState.cs
@@ -819,11 +819,13 @@ namespace Pulsar4X.Client
 
             if (button == MouseButtons.Primary)
             {
-                if (!EntityWindows.ContainsKey(entityGuid))
+                if (!EntityWindows.TryGetValue(entityGuid, out EntityWindow? value))
                 {
-                    EntityWindows.Add(entityGuid, new EntityWindow(entityGuid, starSys));
+                    value = new EntityWindow(entityGuid, starSys);
+                    EntityWindows.Add(entityGuid, value);
                 }
-                EntityWindows[entityGuid].ToggleActive();
+
+                value.ToggleActive();
 
                 if (!ViewPort.IsCtrlPressed)
                 {

--- a/Pulsar4X/Pulsar4X.Client/State/UpdateWindowState.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/UpdateWindowState.cs
@@ -6,6 +6,8 @@ namespace Pulsar4X.Client
     {
         internal static GlobalUIState _uiState;
 
+        internal WindowManager? WindowManager => _uiState.WindowManager;
+
         public abstract bool GetActive();
 
         public virtual void OnSystemTickChange(DateTime newDate) { }

--- a/Pulsar4X/Pulsar4X.Client/State/UpdateWindowState.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/UpdateWindowState.cs
@@ -2,7 +2,7 @@
 
 namespace Pulsar4X.Client
 {
-    public abstract class UpdateWindowState
+    public abstract class UpdateWindowState : IDisposable
     {
         internal static GlobalUIState _uiState;
 
@@ -11,14 +11,9 @@ namespace Pulsar4X.Client
         public virtual void OnSystemTickChange(DateTime newDate) { }
 
         protected UpdateWindowState()
-        {
-            _uiState.UpdateableWindows.Add(this);
-        }
+        {}
 
-        public void Deconstructor()
-        {
-            _uiState.UpdateableWindows.Remove(this);
-        }
-
+        public void Dispose()
+        {}
     }
 }

--- a/Pulsar4X/Pulsar4X.Client/State/WindowManager.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/WindowManager.cs
@@ -7,9 +7,33 @@ namespace Pulsar4X.Client
 {
     internal sealed class WindowManager
     {
+        // Do not modify these collections directly. Use the provided methods to add/remove windows.
         internal List<UpdateWindowState> AllWindows { get; init; } = [];
         internal Dictionary<Type, UniquePulsarGuiWindow> UniqueWindows { get; init; } = [];
         internal Dictionary<string, NamedPulsarGuiWindow> NamedWindows { get; init; } = [];
+
+        // This is a map of window type to all named windows of that type.
+        internal Dictionary<Type, List<NamedPulsarGuiWindow>> NamedWindowsByType { get; init; } = [];
+
+        internal void RenderActiveWindows()
+        {
+            foreach (var item in UniqueWindows.Values.ToArray())
+            {
+                item.Display();
+            }
+
+            /*
+            foreach (var entityWindow in _state.EntityWindows.Values.ToArray())
+            {
+                entityWindow.Display();
+            }
+            */
+
+            foreach (var item in NamedWindows.Values.ToArray())
+            {
+                item.Display();
+            }
+        }
 
         internal NamedPulsarGuiWindow? GetNamedWindow(string name)
         {
@@ -71,8 +95,18 @@ namespace Pulsar4X.Client
 
         internal T AddNamedWindow<T>(string name, T window) where T : NamedPulsarGuiWindow
         {
-            AddWindow(window);
+            // Add to the dictionary first, so if it throws an exception it is not added to the main list.
             NamedWindows.Add(name, window);
+            AddWindow(window);
+
+            if(!NamedWindowsByType.TryGetValue(typeof(T), out var windowList))
+            {
+                NamedWindowsByType.Add(typeof(T), [window]);
+            }
+            else
+            {
+                windowList.Add(window);
+            }
             return window;
         }
 
@@ -93,6 +127,7 @@ namespace Pulsar4X.Client
         {
             UniqueWindows.Clear();
             NamedWindows.Clear();
+            NamedWindowsByType.Clear();
             AllWindows.Clear();
         }
 

--- a/Pulsar4X/Pulsar4X.Client/State/WindowManager.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/WindowManager.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
+namespace Pulsar4X.Client
+{
+    internal sealed class WindowManager
+    {
+        internal List<UpdateWindowState> AllWindows { get; init; } = [];
+        internal Dictionary<Type, UniquePulsarGuiWindow> LoadedWindows { get; init; } = [];
+        internal Dictionary<string, NamedPulsarGuiWindow> LoadedNonUniqueWindows { get; init; } = [];
+
+        internal NamedPulsarGuiWindow? GetNamedWindow(string name)
+        {
+            if (TryGetNamedWindow(name, out var window))
+            {
+                return window;
+            }
+            return null;
+        }
+
+        internal bool TryGetNamedWindow(string name, [NotNullWhen(true)] out NamedPulsarGuiWindow? window)
+        {
+            if (LoadedNonUniqueWindows.TryGetValue(name, out var foundWindow))
+            {
+                window = foundWindow;
+                return true;
+            }
+
+            window = null;
+            return false;
+        }
+
+        internal bool TryGetNamedWindow<T>(string name, [NotNullWhen(true)] out T? window) where T : NamedPulsarGuiWindow
+        {
+            if (TryGetNamedWindow(name, out var foundWindow))
+            {
+                window = (T)foundWindow;
+                return true;
+            }
+            window = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Gets a unique window of type T. Only one instance of a unique window can exist at a time. 
+        /// </summary>
+        /// <typeparam name="T">The type of window.</typeparam>
+        /// <returns>The unique window instance, or <see langword="null"/> if no instance exists.</returns>
+        internal T? GetUniqueWindow<T>() where T : UniquePulsarGuiWindow
+        {
+            if (TryGetUniqueWindow<T>(out var window))
+            {
+                return window;
+            }
+            return null;
+        }
+
+        internal bool TryGetUniqueWindow<T>([NotNullWhen(true)] out T? window) where T : UniquePulsarGuiWindow
+        {
+            if (LoadedWindows.TryGetValue(typeof(T), out var foundWindow))
+            {
+                window = (T)foundWindow;
+                return true;
+            }
+
+            window = null;
+            return false;
+        }
+
+        internal T AddNamedWindow<T>(string name, T window) where T : NamedPulsarGuiWindow
+        {
+            AddWindow(window);
+            LoadedNonUniqueWindows.Add(name, window);
+            return window;
+        }
+
+        internal T AddUniqueWindow<T>(T window) where T : UniquePulsarGuiWindow
+        {
+            AddWindow(window);
+            LoadedWindows.Add(typeof(T), window);
+            return window;
+        }
+
+        internal T AddWindow<T>(T window) where T : UpdateWindowState
+        {
+            AllWindows.Add(window);
+            return window;
+        }
+
+        internal void UnloadAllWindows()
+        {
+            LoadedWindows.Clear();
+            LoadedNonUniqueWindows.Clear();
+            AllWindows.Clear();
+        }
+
+        public IEnumerable<UpdateWindowState> GetActiveWindows() => AllWindows.Where(x => x.GetActive());
+    }
+
+}

--- a/Pulsar4X/Pulsar4X.Client/State/WindowManager.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/WindowManager.cs
@@ -8,8 +8,8 @@ namespace Pulsar4X.Client
     internal sealed class WindowManager
     {
         internal List<UpdateWindowState> AllWindows { get; init; } = [];
-        internal Dictionary<Type, UniquePulsarGuiWindow> LoadedWindows { get; init; } = [];
-        internal Dictionary<string, NamedPulsarGuiWindow> LoadedNonUniqueWindows { get; init; } = [];
+        internal Dictionary<Type, UniquePulsarGuiWindow> UniqueWindows { get; init; } = [];
+        internal Dictionary<string, NamedPulsarGuiWindow> NamedWindows { get; init; } = [];
 
         internal NamedPulsarGuiWindow? GetNamedWindow(string name)
         {
@@ -22,7 +22,7 @@ namespace Pulsar4X.Client
 
         internal bool TryGetNamedWindow(string name, [NotNullWhen(true)] out NamedPulsarGuiWindow? window)
         {
-            if (LoadedNonUniqueWindows.TryGetValue(name, out var foundWindow))
+            if (NamedWindows.TryGetValue(name, out var foundWindow))
             {
                 window = foundWindow;
                 return true;
@@ -59,7 +59,7 @@ namespace Pulsar4X.Client
 
         internal bool TryGetUniqueWindow<T>([NotNullWhen(true)] out T? window) where T : UniquePulsarGuiWindow
         {
-            if (LoadedWindows.TryGetValue(typeof(T), out var foundWindow))
+            if (UniqueWindows.TryGetValue(typeof(T), out var foundWindow))
             {
                 window = (T)foundWindow;
                 return true;
@@ -72,14 +72,14 @@ namespace Pulsar4X.Client
         internal T AddNamedWindow<T>(string name, T window) where T : NamedPulsarGuiWindow
         {
             AddWindow(window);
-            LoadedNonUniqueWindows.Add(name, window);
+            NamedWindows.Add(name, window);
             return window;
         }
 
         internal T AddUniqueWindow<T>(T window) where T : UniquePulsarGuiWindow
         {
             AddWindow(window);
-            LoadedWindows.Add(typeof(T), window);
+            UniqueWindows.Add(typeof(T), window);
             return window;
         }
 
@@ -91,9 +91,17 @@ namespace Pulsar4X.Client
 
         internal void UnloadAllWindows()
         {
-            LoadedWindows.Clear();
-            LoadedNonUniqueWindows.Clear();
+            UniqueWindows.Clear();
+            NamedWindows.Clear();
             AllWindows.Clear();
+        }
+
+        internal void CloseAllWindows()
+        {
+            foreach (var window in UniqueWindows.Values)
+            {
+                window.SetActive(false);
+            }
         }
 
         public IEnumerable<UpdateWindowState> GetActiveWindows() => AllWindows.Where(x => x.GetActive());


### PR DESCRIPTION
## Overview

The `WindowManager` class is aimed to separate the window specific logic from the global UI state object, allowing better separation of concerns between the different orchestration layers.

The PR also includes a refactor of the `OrdersListWindow` class, decoupling the window object from the entity.

## Window Manager

Previous changes in #470 introduced the NamedWindow API and UniqueWindow API to the global state. This PR expands on the approach by extracting those APIs and the relevant registries to a separate object called `WindowManager`. This allows the window management API to not become diluted inside the global state, instead providing an explicit manager to contain all core logic regarding the window lifecycles.

### Window collections
The registry collections of windows have been renamed during the change. The old properties are still available, but marked as obsolete.

| New `WindowManager` collection | Old `GlobalUIState` collection | Description |
| - | - | - |
| AllWindows | UpdateableWindows | A collection of all registered windows. |
| UniqueWindows | LoadedWindows | A dictionary of all registered unique windows. |
| NamedWindows | LoadedNonUniqueWindows | A dictionary of all registered named windows grouped by name. |
| NamedWindowsByType | N / A | A dictionary of all registered named windows grouped by type. |

### Moved API to `WindowManager`
The change moves the following API to the `WindowManager`:
- All methods part of the NamedWindow API
- All methods part of the UniqueWindow API
- `DeactivateAllClosableWindows()`: Changed to `WindowManager.CloseAllWindows()`

### New API in `WindowManager`
In addition to all previously defined NamedWindow API and UniqueWindow API, the new manager class provides the following API:
- `AddWindow`: A generic method that only adds the window to the `AllWindows` collection.
This method is intended to be used to register classes that directly inherit from `UpdateableWindowState`, like `SystemMapRendering`.
- Active Windows utilities:
  - `GetActiveWindows`: A enumeration helper that only returns windows that are currently active.
  - `RenderActiveWindows`: Encapsulates the base render step of all windows. Previously part of `PulsarMainWindow`.
  Note: The entity windows are not included as they are not yet ported to the new system.
- `UnloadAllWindows`: Unloads all windows from the window manager, effectively clearing it.

### Removal of `UpdateableWindowState` self-registration
With the introduction of the window manager, objects of type `UpdateableWindowState` no-longer self-register to the manager. Instead they must be registered via any of the `AddWindow` methods on the manager.

## Orders List Window refactor

Previously each instance of the class `OrdersListWindow` was tightly coupled to an entity on the backend. This detail required the UI to create a new instance for each new entity to be displayed, and to keep the instance alive effectively throughout the entirety of the application.

The new refactor removes that requirement by decoupling the "view" (Window object) from the "model" (Entity), allowing the program to change the entity to which a window is bound. This additionally necessitated a change to the window's naming convention. Previously the entity id was used to disambiguate between duplicate windows. With the new windows being unbound to a specific entity, that can no longer apply, as a single entity can potentially be displayed across multiple windows throughout the application lifetime.

### Window Manager extensions

The decoupling of the order widow and entity, allows the possibility of reuse of existing inactive windows and rebind them to a new entity. Supporting that use case requires a more tight integration between the window factory and the window manager. For that reason, it was chosen for the factory to be represented as extension methods of `WindowManager` in the class `OrderWindowExtensions`.

The new extensions are intended to replace `GetInstance(EntityState)` with `ActivateOrderListWindow(EntityState)`. This fulfils existing use cases where the get instance method was used to immediately activate the window.

Design notes:
1. The extension methods are supposed to be a prototype, potentially to be utilized with other window types that allow multiple active windows.
1. It is my opinion that the window instance shouldn't really require other interaction as all other dynamic data that is external to the view should be provided by the bound model, instead of the code directly interacting with the view.

Quirks:
- The reuse of inactive windows currently persists the position of where the window was last closed.
- Clicking the orders window button in context menu can open multiple order windows for the same entity. This doesn't affect any gameplay much for the moment, as that is purely presentation layer. A potential alternative would be to bring the orders window for the selected entity into focus instead, if it is already open.