### PR TITLE
Fix performance drop during extreme zoom levels.

### DIFF
--- a/Pulsar4X/Pulsar4X.Client.Host/DevTools/PerformanceWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client.Host/DevTools/PerformanceWindow.cs
@@ -116,6 +116,8 @@ namespace Pulsar4X.Client
                 ImGui.Text("Paged mem size:"); ImGui.SameLine();
                 ImGui.Text((p.PagedMemorySize64 / 1048576).ToString() + "MiB");
 
+                ImGui.BeginGroup();
+
                 //plot vars: (label, values, valueOffset, overlayText, scaleMin, scaleMax, graphSize, Stride)
                 //core game processing rate.
                 //ImGui.PlotHistogram("##GRHistogram", _gameRatesDisplay, 10, _timeSpan.TotalSeconds.ToString(), 0, 1f, new ImVec2(0, 80), sizeof(float));
@@ -129,6 +131,24 @@ namespace Pulsar4X.Client
                 ImGui.PlotLines("System Tick ##STPlotlines", ref _systemRates[0], _systemRates.Length, _systemRateIndex, _currentSFPS.ToString(), 0, largestSFPS, new System.Numerics.Vector2(248, 60), sizeof(float));
                 //ui framerate
                 ImGui.PlotHistogram("Frame Rate ##FPSHistogram", ref _frameRates[0], _frameRates.Length, _frameRateIndex, _currentFPS.ToString(), 0f, 10000, new System.Numerics.Vector2(248, 60), sizeof(float));
+
+                ImGui.EndGroup();
+
+                ImGui.SameLine();
+
+                ImGui.BeginGroup();
+
+                if (ImGui.CollapsingHeader("Profile Markers"))
+                {
+                    foreach(var (key, value) in Profiler.Metrics)
+                    {
+                        ImGui.Text(key);
+                        ImGui.SameLine();
+                        ImGui.Text(value.Last.TotalMilliseconds.ToString("0.00ms"));
+                    }
+                }
+
+                ImGui.EndGroup();
 
                 var data = _systemState.StarSystem.ManagerSubpulses.Performance.GetLatestEntry();
                 ImGui.Text($"StarSystemID: {_systemState.StarSystem.ID}");

--- a/Pulsar4X/Pulsar4X.Client/PerformanceMarker.cs
+++ b/Pulsar4X/Pulsar4X.Client/PerformanceMarker.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Pulsar4X.Client;
+
+public static class PerformanceMetrics
+{
+    private readonly static Dictionary<string, PerformanceData> s_Metrics = [];
+
+    internal static PerformanceData RegisterMarker(string markerName)
+    {
+        if (!s_Metrics.TryGetValue(markerName, out var data))
+        {
+            data = new PerformanceData();
+            s_Metrics[markerName] = data;
+        }
+        else
+        {
+            Debug.WriteLine($"Duplicate performance marker name: {markerName}");
+        }
+        return data;
+    }
+}
+
+internal class PerformanceData
+{
+    public long BeginTicks { get; internal set; }
+    public long EndTicks { get; internal set; }
+
+    public TimeSpan Last => TimeSpan.FromTicks(EndTicks - BeginTicks);
+}
+
+public readonly struct PerformanceMarker(string name)
+{
+    private readonly PerformanceData _data = PerformanceMetrics.RegisterMarker(name);
+
+    public TimeSpan Last => _data.Last;
+
+    public void Begin()
+    {
+        _data.BeginTicks = Stopwatch.GetTimestamp();
+    }
+
+    public void End()
+    {
+        _data.EndTicks = Stopwatch.GetTimestamp();
+    }
+}

--- a/Pulsar4X/Pulsar4X.Client/ProfileMarker.cs
+++ b/Pulsar4X/Pulsar4X.Client/ProfileMarker.cs
@@ -4,9 +4,11 @@ using System.Diagnostics;
 
 namespace Pulsar4X.Client;
 
-public static class PerformanceMetrics
+public static class Profiler
 {
     private readonly static Dictionary<string, PerformanceData> s_Metrics = [];
+
+    public static IReadOnlyDictionary<string, PerformanceData> Metrics => s_Metrics;
 
     internal static PerformanceData RegisterMarker(string markerName)
     {
@@ -23,7 +25,7 @@ public static class PerformanceMetrics
     }
 }
 
-internal class PerformanceData
+public class PerformanceData
 {
     public long BeginTicks { get; internal set; }
     public long EndTicks { get; internal set; }
@@ -31,9 +33,9 @@ internal class PerformanceData
     public TimeSpan Last => TimeSpan.FromTicks(EndTicks - BeginTicks);
 }
 
-public readonly struct PerformanceMarker(string name)
+public readonly struct ProfileMarker(string name)
 {
-    private readonly PerformanceData _data = PerformanceMetrics.RegisterMarker(name);
+    private readonly PerformanceData _data = Profiler.RegisterMarker(name);
 
     public TimeSpan Last => _data.Last;
 

--- a/Pulsar4X/Pulsar4X.Client/Rendering/Icons/SysBodyIcon.cs
+++ b/Pulsar4X/Pulsar4X.Client/Rendering/Icons/SysBodyIcon.cs
@@ -176,8 +176,18 @@ namespace Pulsar4X.Client
                         SDL.SetRenderDrawColor(rendererPtr, fillR, fillG, fillB, shape.Color.A);
                         for (int y = -radius; y <= radius; y++)
                         {
+                            // Skip draw call if the y-level is outside the viewport
+                            int yLevel = cy + y;
+                            if(yLevel < 0 || yLevel > (int)camera.ViewPortSize.Y)
+                            {
+                                continue;
+                            }
+
                             int xSpan = (int)Math.Sqrt(radius * radius - y * y);
-                            SDL.RenderLine(rendererPtr, cx - xSpan, cy + y, cx + xSpan, cy + y);
+                            int xStart = Math.Max(0, cx - xSpan);
+                            int xEnd = Math.Min((int)camera.ViewPortSize.X, cx + xSpan);
+
+                            SDL.RenderLine(rendererPtr, xStart, yLevel, xEnd, yLevel);
                         }
                     }
                 }

--- a/Pulsar4X/Pulsar4X.Client/Rendering/Icons/SysBodyIcon.cs
+++ b/Pulsar4X/Pulsar4X.Client/Rendering/Icons/SysBodyIcon.cs
@@ -3,6 +3,7 @@ using Pulsar4X.Api;
 using Pulsar4X.Orbital;
 using SDL3;
 using Pulsar4X.Input;
+using System.Drawing;
 
 namespace Pulsar4X.Client
 {
@@ -64,7 +65,7 @@ namespace Pulsar4X.Client
 
         public bool Contains(System.Drawing.PointF point)
         {
-            System.Numerics.Vector2 v = new (ViewScreenPos.X, ViewScreenPos.Y);
+            System.Numerics.Vector2 v = new(ViewScreenPos.X, ViewScreenPos.Y);
             return System.Numerics.Vector2.Distance(v, point.ToVector2()) <= Scale * 100;
         }
 
@@ -152,6 +153,18 @@ namespace Pulsar4X.Client
                     int cx = ViewScreenPos.X;
                     int cy = ViewScreenPos.Y;
                     int radius = (int)(Scale * 100);
+
+
+                    // Implements basic frustum culling for the icon.
+                    // Drop icons that are fully out of viewbox.
+                    var aabb = new Rectangle(cx - radius, cy - radius, radius * 2, radius * 2);
+                    if (aabb.Right < 0 || aabb.Bottom < 0)
+                        return;
+
+                    var vps = camera.ViewPortSize;
+                    if (aabb.Left > vps.X || aabb.Top > vps.Y)
+                        return;
+
 
                     if (radius > 0)
                     {

--- a/Pulsar4X/Pulsar4X.Client/Rendering/SystemMapRendering.cs
+++ b/Pulsar4X/Pulsar4X.Client/Rendering/SystemMapRendering.cs
@@ -462,19 +462,46 @@ namespace Pulsar4X.Client.Rendering
             }
         }
 
+        static readonly PerformanceMarker s_PerfMarkDrawUI = new("DrawUI");
+        static readonly PerformanceMarker s_PerfMarkDrawOrbit = new("DrawOrbit");
+        static readonly PerformanceMarker s_PerfMarkDrawMoveIcons = new("DrawMovabbles");
+        static readonly PerformanceMarker s_PerfMarkDrawEntity = new("DrawEntity");
+        static readonly PerformanceMarker s_PerfMarkDrawBody = new("DrawBody");
+        static readonly PerformanceMarker s_PerfMarkDrawExtra = new("DrawExtras");
+        static readonly PerformanceMarker s_PerfMarkDrawLabels = new("DrawLabels");
+
         internal void Draw()
         {
             s_DrawUpdatePerfMark.Begin();
 
+            s_PerfMarkDrawUI.Begin();
             DrawIcons(UIWidgets.Values);
-            DrawIcons(_orbitRings.Values);
-            DrawIcons(_moveIcons.Values);
-            DrawIcons(_entityIcons.Values);
-            DrawIcons(_bodyIcons.Values);
-            DrawIcons(SelectedEntityExtras);
+            s_PerfMarkDrawUI.End();
 
+            s_PerfMarkDrawOrbit.Begin();
+            DrawIcons(_orbitRings.Values);
+            s_PerfMarkDrawOrbit.End();
+
+            s_PerfMarkDrawMoveIcons.Begin();
+            DrawIcons(_moveIcons.Values);
+            s_PerfMarkDrawMoveIcons.End();
+
+            s_PerfMarkDrawEntity.Begin();
+            DrawIcons(_entityIcons.Values);
+            s_PerfMarkDrawEntity.End();
+
+            s_PerfMarkDrawBody.Begin();
+            DrawIcons(_bodyIcons.Values);
+            s_PerfMarkDrawBody.End();
+
+            s_PerfMarkDrawExtra.Begin();
+            DrawIcons(SelectedEntityExtras);
+            s_PerfMarkDrawExtra.End();
+
+            s_PerfMarkDrawLabels.Begin();
             foreach (var i in _visibleLabels)
                 i.Draw(_window.Renderer, _camera);
+            s_PerfMarkDrawLabels.End();
 
             s_DrawUpdatePerfMark.End();
         }

--- a/Pulsar4X/Pulsar4X.Client/Rendering/SystemMapRendering.cs
+++ b/Pulsar4X/Pulsar4X.Client/Rendering/SystemMapRendering.cs
@@ -10,7 +10,7 @@ namespace Pulsar4X.Client.Rendering
 {
     internal class SystemMapRendering : UpdateWindowState
     {
-        static readonly PerformanceMarker s_DrawUpdatePerfMark = new("DrawUpdate");
+        static readonly ProfileMarker s_DrawUpdatePerfMark = new("DrawUpdate");
 
         GlobalUIState _state;
         string? _systemId;
@@ -462,13 +462,13 @@ namespace Pulsar4X.Client.Rendering
             }
         }
 
-        static readonly PerformanceMarker s_PerfMarkDrawUI = new("DrawUI");
-        static readonly PerformanceMarker s_PerfMarkDrawOrbit = new("DrawOrbit");
-        static readonly PerformanceMarker s_PerfMarkDrawMoveIcons = new("DrawMovabbles");
-        static readonly PerformanceMarker s_PerfMarkDrawEntity = new("DrawEntity");
-        static readonly PerformanceMarker s_PerfMarkDrawBody = new("DrawBody");
-        static readonly PerformanceMarker s_PerfMarkDrawExtra = new("DrawExtras");
-        static readonly PerformanceMarker s_PerfMarkDrawLabels = new("DrawLabels");
+        static readonly ProfileMarker s_PerfMarkDrawUI = new("DrawUI");
+        static readonly ProfileMarker s_PerfMarkDrawOrbit = new("DrawOrbit");
+        static readonly ProfileMarker s_PerfMarkDrawMoveIcons = new("DrawMovabbles");
+        static readonly ProfileMarker s_PerfMarkDrawEntity = new("DrawEntity");
+        static readonly ProfileMarker s_PerfMarkDrawBody = new("DrawBody");
+        static readonly ProfileMarker s_PerfMarkDrawExtra = new("DrawExtras");
+        static readonly ProfileMarker s_PerfMarkDrawLabels = new("DrawLabels");
 
         internal void Draw()
         {

--- a/Pulsar4X/Pulsar4X.Client/Rendering/SystemMapRendering.cs
+++ b/Pulsar4X/Pulsar4X.Client/Rendering/SystemMapRendering.cs
@@ -10,6 +10,8 @@ namespace Pulsar4X.Client.Rendering
 {
     internal class SystemMapRendering : UpdateWindowState
     {
+        static readonly PerformanceMarker s_DrawUpdatePerfMark = new("DrawUpdate");
+
         GlobalUIState _state;
         string? _systemId;
         Camera _camera;
@@ -462,6 +464,8 @@ namespace Pulsar4X.Client.Rendering
 
         internal void Draw()
         {
+            s_DrawUpdatePerfMark.Begin();
+
             DrawIcons(UIWidgets.Values);
             DrawIcons(_orbitRings.Values);
             DrawIcons(_moveIcons.Values);
@@ -471,6 +475,8 @@ namespace Pulsar4X.Client.Rendering
 
             foreach (var i in _visibleLabels)
                 i.Draw(_window.Renderer, _camera);
+
+            s_DrawUpdatePerfMark.End();
         }
 
         void DrawIcons(IEnumerable<IDrawData> icons)


### PR DESCRIPTION
The PR fixes an extreme performance regression of the client when zoomed in on an object.

The main offending part is SysBodyIcon, which generates huge render calls for all system body objects in the solar system.

### Fix implementation
- Frustrum culling is performed during the draw phase, skipping system bodies that fall completely outside the viewport.
- Calls to draw lines are clamped to only draw inside the viewport's visible area.

### Metrics
Before the optimization, zooming in on earth with ZoomLevel `~4e+7` (Debug window) dropped frame rate to ~37 fps. After the optimization the framerate does not experience any noticeable drops until the system icons begin to break at around `~1.45e+9` when the system icon code begins to break.

## Profiler

A new Profiler class is added for the UI, due to the game engine profiler not being available in the client library.
It is roughly based on Unity's profile marker implementation, relying on the markers being static variables to maintain a reference to the profile block data.