### PR TITLE
Decoupled EntityWindow from being bound to a specific entity.

### DIFF
--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/EntityWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/EntityWindow.cs
@@ -9,10 +9,54 @@ using Pulsar4X.Client.Interface.Widgets;
 
 namespace Pulsar4X.Client
 {
+    public record EntityWindowEntity(int EntityId, string SystemId);
+
+    internal static class EntityWindowExtensions
+    {
+        private static int _idCounter = 0;
+
+        /// <summary>
+        /// Activates a window displaying the orders for a given entity.
+        /// </summary>
+        /// <param name="manager">The window manager instance.</param>
+        /// <param name="entity">The entity requested for display.</param>
+        public static EntityWindow ActivateEntityWindow(this WindowManager manager, EntityWindowEntity entity)
+        {
+            void DeactivateAllOtherWindows(EntityWindow keepActive)
+            {
+                if (manager.NamedWindowsByType.TryGetValue(typeof(EntityWindow), out var windows))
+                {
+                    foreach (var window in windows.Cast<EntityWindow>().Where(w => !ReferenceEquals(w, keepActive)))
+                    {
+                        window.SetActive(false);
+                    }
+                }
+            }
+
+            if (manager.NamedWindowsByType.TryGetValue(typeof(EntityWindow), out var windowList))
+            {
+                // Reuse an existing inactive window if available
+                foreach (var window in windowList.Cast<EntityWindow>().Where(w => !w.GetActive()))
+                {
+                    window.SetEntity(entity.EntityId, entity.SystemId);
+                    window.SetActive(true);
+                    DeactivateAllOtherWindows(window);
+                    return window;
+                }
+            }
+            string name = "EntityWindow|" + _idCounter++;
+            var entityWindow = new EntityWindow(name, entity.EntityId, entity.SystemId);
+            manager.AddNamedWindow(name, entityWindow);
+            entityWindow.SetActive(true);
+            DeactivateAllOtherWindows(entityWindow);
+            return entityWindow;
+        }
+    }
+
     public class EntityWindow : NamedPulsarGuiWindow
     {
-        public int EntityId { get; }
-        public string SystemId { get; }
+        public int EntityId { get; private set; }
+        public string SystemId { get; private set; }
         public string Title { get; private set; } = "Unknown";
 
         // Re-resolved each frame: system snapshots are replaced wholesale by server pushes.
@@ -35,11 +79,17 @@ namespace Pulsar4X.Client
         private float _animationProgress = 0f;
         private DateTime _animationStartTime;
 
-        public EntityWindow(int entityId, string systemId) : base("EntityWindow|" + entityId)
+        internal EntityWindow(string name, int entityId, string systemId) : base(name)
         {
             EntityId = entityId;
             SystemId = systemId;
             _flags = ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoTitleBar;
+        }
+
+        public void SetEntity(int entityId, string systemId)
+        {
+            EntityId = entityId;
+            SystemId = systemId;
         }
 
         public new void SetActive(bool activeVal = true)
@@ -140,7 +190,7 @@ namespace Pulsar4X.Client
 
         internal override void Display()
         {
-            if(!IsActive && _animationState == AnimationState.Closed) return;
+            if (!IsActive && _animationState == AnimationState.Closed) return;
 
             UpdateAnimation();
 

--- a/Pulsar4X/Pulsar4X.Client/Interface/Windows/UniquePulsarGuiWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/Interface/Windows/UniquePulsarGuiWindow.cs
@@ -3,6 +3,9 @@ using System;
 
 namespace Pulsar4X.Client
 {
+    /// <summary>
+    /// A base class for GUI windows that are unique to the application client.
+    /// </summary>
     public abstract class UniquePulsarGuiWindow : UpdateWindowState
     {
         protected ImGuiWindowFlags _flags = ImGuiWindowFlags.None;
@@ -15,10 +18,7 @@ namespace Pulsar4X.Client
         public bool ClickedEntityIsPrimary = true;
 
         protected UniquePulsarGuiWindow(string name)
-        {
-            int x = 1;
-            // _uiState.LoadedWindows[this.GetType()] = this;
-        }
+        {}
 
         public void SetActive(bool ActiveVal = true)
         {

--- a/Pulsar4X/Pulsar4X.Client/PulsarMainWindow.cs
+++ b/Pulsar4X/Pulsar4X.Client/PulsarMainWindow.cs
@@ -249,11 +249,6 @@ namespace Pulsar4X.Client
             // Render any windows that have registered themselves
             _state.WindowManager.RenderActiveWindows();
 
-            foreach (var entityWindow in _state.EntityWindows.Values.ToArray())
-            {
-                entityWindow.Display();
-            }
-
             // Render the maneuver node panel overlay (if active)
             _state.DisplayManeuverNodePanel();
         }

--- a/Pulsar4X/Pulsar4X.Client/State/GlobalUIState.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/GlobalUIState.cs
@@ -128,7 +128,6 @@ namespace Pulsar4X.Client
         internal EntityState? PrimaryEntity { get; private set; }
         //internal SpaceMasterVM SpaceMasterVM;
         internal bool SMenabled = false;
-        internal Dictionary<int, EntityWindow> EntityWindows { get; private set; } = new();
         private string _previousSystemIdBeforeSM = "";
 
         internal Stack<IHotKeyHandler> HotKeys { get; private set; } = new();
@@ -368,7 +367,6 @@ namespace Pulsar4X.Client
             GameClient = null;
             GameInfo = null;
             WindowManager.UnloadAllWindows();
-            EntityWindows.Clear();
             _savedCameraStates.Clear();
             LastClickedEntity = null;
             PrimaryEntity = null;
@@ -819,24 +817,7 @@ namespace Pulsar4X.Client
 
             if (button == MouseButtons.Primary)
             {
-                if (!EntityWindows.TryGetValue(entityGuid, out EntityWindow? value))
-                {
-                    value = new EntityWindow(entityGuid, starSys);
-                    WindowManager.AddWindow(value);
-                    EntityWindows.Add(entityGuid, value);
-                }
-
-                value.ToggleActive();
-
-                if (!ViewPort.IsCtrlPressed)
-                {
-                    foreach (var (id, window) in EntityWindows)
-                    {
-                        if (id == entityGuid) continue;
-
-                        window.SetActive(false);
-                    }
-                }
+                WindowManager.ActivateEntityWindow(new EntityWindowEntity(entityGuid, starSys));
             }
         }
 

--- a/Pulsar4X/Pulsar4X.Client/State/WindowManager.cs
+++ b/Pulsar4X/Pulsar4X.Client/State/WindowManager.cs
@@ -22,13 +22,6 @@ namespace Pulsar4X.Client
                 item.Display();
             }
 
-            /*
-            foreach (var entityWindow in _state.EntityWindows.Values.ToArray())
-            {
-                entityWindow.Display();
-            }
-            */
-
             foreach (var item in NamedWindows.Values.ToArray())
             {
                 item.Display();


### PR DESCRIPTION
The PR decouples the entity window from being bound to a specific entity for the entire duration of its lifecycle.
This allows a created entity window object to be reused with different entities after is has been deactivated.

This mirrors OrdersListWindow in implementation, with the only difference being that the activation function closes all other entity windows. This reduces the number of active entity windows from N-selected to approximately 2, while previously all entities would have registered a new entity window.

The entity windows are also standardized, no-longer requiring separate management (eg. `EntityWindows` dictionary) from normal named windows.